### PR TITLE
Read sandboxing mode from sailjaild

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -14,6 +14,7 @@ Source1:    %{name}.privileges
 Requires:   mce >= 1.87.0
 Requires:   pulseaudio-modules-nemo-mainvolume >= 6.0.19
 Requires:   user-managerd >= 0.3.0
+Requires:   sailjail-daemon
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5Core)

--- a/src/components/launcheritem.cpp
+++ b/src/components/launcheritem.cpp
@@ -34,6 +34,7 @@
 
 #include "launcheritem.h"
 #include "launchermodel.h"
+#include "logging.h"
 
 #ifdef HAVE_CONTENTACTION
 #include <contentaction.h>
@@ -162,12 +163,12 @@ void LauncherItem::fetchSandboxingInfo()
         if (reply.isError()) {
             auto error = reply.error();
             if (error.type() == QDBusError::InvalidArgs && error.message().startsWith(SailjailInvalidName))
-                qDebug() << "No sandboxing info for" << sandboxingName();
+                qCDebug(lcLipstickAppLaunchLog) << "No sandboxing info for" << sandboxingName();
             else
-                qWarning() << "Error fetching sandboxing info for" << sandboxingName()
-                           << error.name() << error.message();
+                qCWarning(lcLipstickAppLaunchLog) << "Error fetching sandboxing info for"
+                                                  << sandboxingName() << error.name() << error.message();
         } else {
-            qDebug() << "Received sandboxing info for" << sandboxingName();
+            qCDebug(lcLipstickAppLaunchLog) << "Received sandboxing info for" << sandboxingName();
             const auto map = reply.argumentAt<0>();
             m_sandboxed = map[SailjailInfoKeyMode].variant().toString() != SailjailModeNone;
             m_sandboxingInfoFetched = true;
@@ -440,7 +441,7 @@ void LauncherItem::launchWithArguments(const QStringList &arguments)
                     NULL,
                     &error);
         if (error != NULL) {
-            qWarning() << "Failed to execute" << filename() << error->message;
+            qCWarning(lcLipstickAppLaunchLog) << "Failed to execute" << filename() << error->message;
             g_error_free(error);
         }
         g_list_foreach(uris, (GFunc)g_free, NULL);

--- a/src/components/launcheritem.cpp
+++ b/src/components/launcheritem.cpp
@@ -24,6 +24,10 @@
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include <QUrl>
+#include <QDBusConnection>
+#include <QDBusPendingCall>
+#include <QDBusPendingReply>
+#include <QDBusMetaType>
 
 #include <mdesktopentry.h>
 #include <mremoteaction.h>
@@ -42,6 +46,17 @@
 
 #include <QDebug>
 
+// TODO: These values should be in some header coming from sailjail
+const auto SailjailService = QStringLiteral("org.sailfishos.sailjaild1");
+const auto SailjailPath = QStringLiteral("/org/sailfishos/sailjaild1");
+const auto SailjailInterface = QStringLiteral("org.sailfishos.sailjaild1");
+const auto SailjailGetAppInfo = QStringLiteral("GetAppInfo");
+const auto SailjailInvalidName = QStringLiteral("Invalid application name: ");
+const auto SailjailInfoKeyMode = QStringLiteral("Mode");
+const auto SailjailModeNone = QStringLiteral("None");
+
+typedef QMap<QString, QDBusVariant> PropertyMap;
+
 LauncherItem::LauncherItem(const QString &filePath, QObject *parent)
     : QObject(parent)
     , m_isLaunching(false)
@@ -53,9 +68,13 @@ LauncherItem::LauncherItem(const QString &filePath, QObject *parent)
     , m_customIconFilename("")
     , m_serial(0)
     , m_isBlacklisted(false)
+    , m_mimeTypesPopulated(false)
+    , m_sandboxingInfoFetched(false)
+    , m_sandboxed(false)
 {
     if (!filePath.isEmpty()) {
         setFilePath(filePath);
+        initializeSandboxingInfo();
     }
 
     // TODO: match the PID of the window thumbnails with the launcher processes
@@ -75,9 +94,12 @@ LauncherItem::LauncherItem(const QString &packageName, const QString &label,
     , m_serial(0)
     , m_isBlacklisted(false)
     , m_mimeTypesPopulated(false)
+    , m_sandboxingInfoFetched(false)
+    , m_sandboxed(false)
 {
     if (!desktopFile.isEmpty()) {
         setFilePath(desktopFile);
+        initializeSandboxingInfo();
     }
 }
 
@@ -114,6 +136,56 @@ void LauncherItem::setFilePath(const QString &filePath)
     }
 
     emit this->itemChanged();
+}
+
+void LauncherItem::initializeSandboxingInfo()
+{
+    qDBusRegisterMetaType<PropertyMap>();
+    auto bus = QDBusConnection::systemBus();
+    bus.connect(SailjailService, SailjailPath, SailjailInterface, "ApplicationAdded",
+                this, SLOT(sandboxingInfoChanged(QString)));
+    bus.connect(SailjailService, SailjailPath, SailjailInterface, "ApplicationChanged",
+                this, SLOT(sandboxingInfoChanged(QString)));
+    fetchSandboxingInfo();
+}
+
+void LauncherItem::fetchSandboxingInfo()
+{
+    auto message = QDBusMessage::createMethodCall(SailjailService, SailjailPath, SailjailInterface,
+                                                  SailjailGetAppInfo);
+    message.setArguments({ sandboxingName() });
+    QDBusPendingCall async = QDBusConnection::systemBus().asyncCall(message);
+    QDBusPendingCallWatcher *call = new QDBusPendingCallWatcher(async, this);
+    connect(call, &QDBusPendingCallWatcher::finished,
+            this, [this](QDBusPendingCallWatcher *call) {
+        QDBusPendingReply<PropertyMap> reply = *call;
+        if (reply.isError()) {
+            auto error = reply.error();
+            if (error.type() == QDBusError::InvalidArgs && error.message().startsWith(SailjailInvalidName))
+                qDebug() << "No sandboxing info for" << sandboxingName();
+            else
+                qWarning() << "Error fetching sandboxing info for" << sandboxingName()
+                           << error.name() << error.message();
+        } else {
+            qDebug() << "Received sandboxing info for" << sandboxingName();
+            const auto map = reply.argumentAt<0>();
+            m_sandboxed = map[SailjailInfoKeyMode].variant().toString() != SailjailModeNone;
+            m_sandboxingInfoFetched = true;
+            emit itemChanged();
+        }
+        call->deleteLater();
+    });
+}
+
+void LauncherItem::sandboxingInfoChanged(const QString &appname)
+{
+    if (appname == sandboxingName())
+        fetchSandboxingInfo();
+}
+
+QString LauncherItem::sandboxingName() const
+{
+    return QFileInfo(filePath()).completeBaseName();
 }
 
 QString LauncherItem::filePath() const
@@ -251,7 +323,11 @@ bool LauncherItem::shouldDisplay() const
 
 bool LauncherItem::isSandboxed() const
 {
-    return !m_desktopEntry.isNull() ? m_desktopEntry->isSandboxed() : false;
+    if (m_sandboxingInfoFetched) {
+        return m_sandboxed;
+    } else {
+        return !m_desktopEntry.isNull() ? m_desktopEntry->isSandboxed() : false;
+    }
 }
 
 bool LauncherItem::isValid() const

--- a/src/components/launcheritem.h
+++ b/src/components/launcheritem.h
@@ -39,6 +39,7 @@
 
 class MDesktopEntry;
 class MRemoteAction;
+class QDBusPendingCallWatcher;
 
 class LIPSTICK_EXPORT LauncherItem : public QObject
 {
@@ -138,7 +139,14 @@ signals:
 protected:
     void timerEvent(QTimerEvent *event);
 
+private slots:
+    void sandboxingInfoChanged(const QString &appname);
+
 private:
+    void initializeSandboxingInfo();
+    void fetchSandboxingInfo();
+    QString sandboxingName() const;
+
     QSharedPointer<MDesktopEntry> m_desktopEntry;
     QBasicTimer m_launchingTimeout;
     QVector<QRegExp> m_mimeTypes;
@@ -153,6 +161,8 @@ private:
     int m_serial;
     bool m_isBlacklisted;
     bool m_mimeTypesPopulated;
+    bool m_sandboxingInfoFetched;
+    bool m_sandboxed;
 };
 
 #endif // LAUNCHERITEM_H

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -16,3 +16,4 @@
 
 Q_LOGGING_CATEGORY(lcLipstickCoreLog, "org.sailfishos.lipstick", QtWarningMsg)
 Q_LOGGING_CATEGORY(lcLipstickHwcLog, "org.sailfishos.lipstick.hwc", QtWarningMsg)
+Q_LOGGING_CATEGORY(lcLipstickAppLaunchLog, "org.sailfishos.lipstick.applaunch", QtWarningMsg)

--- a/src/logging.h
+++ b/src/logging.h
@@ -20,5 +20,6 @@
 
 Q_DECLARE_LOGGING_CATEGORY(lcLipstickCoreLog)
 Q_DECLARE_LOGGING_CATEGORY(lcLipstickHwcLog)
+Q_DECLARE_LOGGING_CATEGORY(lcLipstickAppLaunchLog)
 
 #endif

--- a/tests/ut_launchermodel/ut_launchermodel.pro
+++ b/tests/ut_launchermodel/ut_launchermodel.pro
@@ -25,6 +25,7 @@ SOURCES += \
     $$COMPONENTSSRCDIR/launcherdbus.cpp \
     $$STUBSDIR/stubbase.cpp \
     $$UTILITYSRCDIR/qobjectlistmodel.cpp \
+    $$SRCDIR/logging.cpp \
 
 HEADERS += \
     ut_launchermodel.h \
@@ -34,5 +35,6 @@ HEADERS += \
     $$COMPONENTSSRCDIR/launcherdbus.h \
     $$UTILITYSRCDIR/qobjectlistmodel.h \
     $$3RDPARTYSRCDIR/synchronizelists.h \
+    $$SRCDIR/logging.h \
     /usr/include/mlite5/mdesktopentry.h \
 


### PR DESCRIPTION
Call sailjaild's GetAppInfo to get sandboxing mode for apps. This is
needed to make lipstick prompt for sailjail when a legacy app is
sandboxed. In that case the information can not be read from the desktop
file. Without this change prompting is left to sailjail command which
also checks whether the app can be launched. This should also simplify
cover handling by allowing lipstick to manage when to show app cover
after the prompt is approved.