### PR TITLE
[lipstick] Fix crash when hidden desktop files are removed. Fixes JB#54889 OMP#JOLLA-249

### DIFF
--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -710,13 +710,6 @@ int LauncherModel::findItem(const QString &path, LauncherItem **item)
     }
 
     if (item) {
-        for (LauncherItem *hiddenItem : m_hiddenLaunchers) {
-            if (hiddenItem->filePath() == path || hiddenItem->filename() == path) {
-                *item = hiddenItem;
-                return -1;
-            }
-        }
-
         *item = nullptr;
     }
 


### PR DESCRIPTION
onFilesUpdated() when notified of a removed file would query visible
items using itemInModel() and fall back to takeHiddenItem() to query
hidden items and then delete the found item. But itemInModel in a change
in behavior was returning hidden items too so the item was deleted but
the pointer not removed from the hidden items list.

Reverting to the old behavior of only returning visible items from
itemInModel means the takeHiddenItem code path will be taken and the
item removed from hidden items list before being deleted.