### PR TITLE
Emit application id for topmost window.

### DIFF
--- a/src/compositor/compositor.xml
+++ b/src/compositor/compositor.xml
@@ -10,5 +10,11 @@
     <signal name="privateTopmostWindowProcessIdChanged">
       <arg name="pid" type="i"/>
     </signal>
+    <method name="privateTopmostWindowPolicyApplicationId">
+      <arg name="id" type="s" direction="out"/>
+    </method>
+    <signal name="privateTopmostWindowPolicyApplicationIdChanged">
+      <arg name="id" type="s"/>
+    </signal>
   </interface>
 </node>

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -340,6 +340,14 @@ void LipstickCompositor::setTopmostWindowId(int id)
             m_topmostWindowProcessId = pid;
             emit privateTopmostWindowProcessIdChanged(m_topmostWindowProcessId);
         }
+
+        QString applicationId = window && !window->policyApplicationId().isEmpty()
+                                ? window->policyApplicationId() : "none";
+
+        if (m_topmostWindowPolicyApplicationId != applicationId) {
+            m_topmostWindowPolicyApplicationId = applicationId;
+            emit privateTopmostWindowPolicyApplicationIdChanged(m_topmostWindowPolicyApplicationId);
+        }
     }
 }
 

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -111,6 +111,7 @@ public:
     int topmostWindowId() const { return m_topmostWindowId; }
     void setTopmostWindowId(int id);
     int privateTopmostWindowProcessId() const { return m_topmostWindowProcessId; }
+    QString privateTopmostWindowPolicyApplicationId() const { return m_topmostWindowPolicyApplicationId; }
 
     Qt::ScreenOrientation topmostWindowOrientation() const { return m_topmostWindowOrientation; }
     void setTopmostWindowOrientation(Qt::ScreenOrientation topmostWindowOrientation);
@@ -172,6 +173,7 @@ signals:
     void homeActiveChanged();
     void topmostWindowIdChanged();
     void privateTopmostWindowProcessIdChanged(int pid);
+    void privateTopmostWindowPolicyApplicationIdChanged(QString applicationId);
     void topmostWindowOrientationChanged();
     void screenOrientationChanged();
     void sensorOrientationChanged();
@@ -251,6 +253,7 @@ private:
 
     int m_topmostWindowId;
     int m_topmostWindowProcessId;
+    QString m_topmostWindowPolicyApplicationId;
     Qt::ScreenOrientation m_topmostWindowOrientation;
     Qt::ScreenOrientation m_screenOrientation;
     Qt::ScreenOrientation m_sensorOrientation;

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -59,6 +59,8 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
         connect(surface, &QWaylandSurface::titleChanged, this, &LipstickCompositorWindow::titleChanged);
         connect(surface, &QWaylandSurface::configure, this, &LipstickCompositorWindow::committed);
     }
+
+    updatePolicyApplicationId();
 }
 
 LipstickCompositorWindow::~LipstickCompositorWindow()
@@ -66,6 +68,42 @@ LipstickCompositorWindow::~LipstickCompositorWindow()
     // We don't want tryRemove() posting an event anymore, we're dying anyway
     m_removePosted = true;
     LipstickCompositor::instance()->windowDestroyed(this);
+}
+
+void LipstickCompositorWindow::updatePolicyApplicationId()
+{
+    if (m_processId <= 0) {
+        return;
+    }
+
+    QString statFile = QString::fromLatin1("/proc/%1/stat").arg(m_processId);
+    QFile f(statFile);
+    if (!f.open(QIODevice::ReadOnly)) {
+        qWarning() << Q_FUNC_INFO << "Cannot open proc stat for" << statFile;
+        return;
+    }
+
+    // stat line values are split by ' ' in /proc/*/stat
+    QByteArray data = f.readAll();
+    QList<QByteArray> statFields = data.split(' ');
+
+    // starttime is field 22, format %lld in stat, see man page for details.
+    if (statFields.count() < 22) {
+        qWarning() << Q_FUNC_INFO << "fields count < 22";
+        return;
+    }
+
+    QString starttime = QString::fromUtf8(statFields.at(21));
+    bool ok;
+    qint64 value = starttime.toLongLong(&ok, 10);
+
+    if (!ok) {
+        qWarning() << Q_FUNC_INFO << "toLongLong not ok:" << starttime;
+        return;
+    }
+
+    // format value as hex
+    m_policyApplicationId = QString("%1").arg(value, 0, 16);
 }
 
 QVariant LipstickCompositorWindow::userData() const
@@ -95,6 +133,11 @@ bool LipstickCompositorWindow::isAlien() const
 qint64 LipstickCompositorWindow::processId() const
 {
     return m_processId;
+}
+
+QString LipstickCompositorWindow::policyApplicationId() const
+{
+    return m_policyApplicationId;
 }
 
 bool LipstickCompositorWindow::delayRemove() const

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -49,6 +49,7 @@ public:
 
     int windowId() const;
     qint64 processId() const;
+    QString policyApplicationId() const;
 
     bool delayRemove() const;
     void setDelayRemove(bool);
@@ -105,7 +106,10 @@ private:
     void refreshGrabbedKeys();
     void handleTouchEvent(QTouchEvent *e);
 
+    void updatePolicyApplicationId();
+
     qint64 m_processId;
+    QString m_policyApplicationId;
     int m_windowId;
     bool m_isAlien;
     QString m_category;


### PR DESCRIPTION
Application id is used to match topmost applications to their audio
streams.