### PR TITLE
[touchscreen] Also mouse events terminate waiting for touch. JB#55676

### DIFF
--- a/src/touchscreen/touchscreen.cpp
+++ b/src/touchscreen/touchscreen.cpp
@@ -203,11 +203,16 @@ bool TouchScreen::eventFilter(QObject *, QEvent *event)
         }
 
         if (d->waitForTouchBegin) {
-            if (event->type() != QEvent::TouchBegin) {
+            switch (event->type()) {
+            case QEvent::TouchBegin:
+            case QEvent::MouseButtonPress:
+            case QEvent::MouseMove:
+                d->waitForTouchBegin = false;
+                break;
+            default:
                 event->accept();
                 return true;
             }
-            d->waitForTouchBegin = false;
         }
     }
 


### PR DESCRIPTION
After display unblank mouse cursor does not move before screen is tapped.
This happens because logic dealing with normalization of touch event
processing over display power down periods blocks also mouse events.

Unblock touch and mouse event processing also when mouse move / button
press events are seen.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>