### PR TITLE
[lipstick] Force reloading hidden launcher when file changes. JB#56017

### DIFF
--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -235,7 +235,8 @@ void LauncherModel::onFilesUpdated(const QStringList &added,
                     updateItemsWithIcon(item->getOriginalIconId(), QString());
                 }
             } else if ((item = takeHiddenItem(filename))) {
-                addItemIfValid(item);
+                delete item;
+                addItemIfValid(filename);
             } else {
                 // No item yet (maybe it had Hidden=true before), try to see if
                 // we should show the item now
@@ -816,12 +817,8 @@ QVariant LauncherModel::launcherPos(const QString &path)
 LauncherItem *LauncherModel::addItemIfValid(const QString &path)
 {
     LAUNCHER_DEBUG("Creating LauncherItem for desktop entry" << path);
+    LauncherItem *item = new LauncherItem(path, this);
 
-    return addItemIfValid(new LauncherItem(path, this));
-}
-
-LauncherItem *LauncherModel::addItemIfValid(LauncherItem *item)
-{
     bool isValid = item->isValid();
     bool shouldDisplay = item->shouldDisplay() && displayCategory(item);
 

--- a/src/components/launchermodel.h
+++ b/src/components/launchermodel.h
@@ -118,7 +118,6 @@ private:
     LauncherItem *packageInModel(const QString &packageName);
     QVariant launcherPos(const QString &path);
     LauncherItem *addItemIfValid(const QString &path);
-    LauncherItem *addItemIfValid(LauncherItem *item);
     void updateItemsWithIcon(const QString &iconId, const QString &filename);
     void updateWatchedDBusServices();
     void setTemporary(LauncherItem *item);


### PR DESCRIPTION
MDesktopEntry doesn't support updating of the values when file changes.