### PR TITLE
[notificationmanager] Identify xdg-dbus-proxy clients

### DIFF
--- a/tests/stubs/notificationmanager_stub.h
+++ b/tests/stubs/notificationmanager_stub.h
@@ -1,7 +1,7 @@
 /***************************************************************************
 **
-** Copyright (c) 2012 - 2019 Jolla Ltd.
-** Copyright (c) 2019 Open Mobile Platform LLC.
+** Copyright (c) 2012 - 2021 Jolla Ltd.
+** Copyright (c) 2019 - 2021 Open Mobile Platform LLC.
 **
 ** This file is part of lipstick.
 **
@@ -17,7 +17,6 @@
 
 #include "notificationmanager.h"
 #include <stubbase.h>
-
 
 // 1. DECLARE STUB
 // FIXME - stubgen is not yet finished
@@ -45,6 +44,10 @@ public:
     virtual void reportModifications();
     virtual void NotificationManagerConstructor(QObject *parent, bool owner);
     virtual void NotificationManagerDestructor();
+    virtual void identifiedGetNotifications();
+    virtual void identifiedGetNotificationsByCategory();
+    virtual void identifiedCloseNotification();
+    virtual void identifiedNotify();
 };
 
 // 2. IMPLEMENT STUB
@@ -190,7 +193,21 @@ void NotificationManagerStub::NotificationManagerDestructor()
 
 }
 
+void NotificationManagerStub::identifiedGetNotifications()
+{
+}
 
+void NotificationManagerStub::identifiedGetNotificationsByCategory()
+{
+}
+
+void NotificationManagerStub::identifiedCloseNotification()
+{
+}
+
+void NotificationManagerStub::identifiedNotify()
+{
+}
 
 // 3. CREATE A STUB INSTANCE
 NotificationManagerStub gDefaultNotificationManagerStub;
@@ -305,6 +322,35 @@ NotificationManager::~NotificationManager()
 QString NotificationManager::systemApplicationName() const
 {
     return QString();
+}
+
+void NotificationManager::identifiedGetNotifications()
+{
+    gNotificationManagerStub->identifiedGetNotifications();
+}
+
+void NotificationManager::identifiedGetNotificationsByCategory()
+{
+    gNotificationManagerStub->identifiedGetNotificationsByCategory();
+}
+
+void NotificationManager::identifiedCloseNotification()
+{
+    gNotificationManagerStub->identifiedCloseNotification();
+}
+
+void NotificationManager::identifiedNotify()
+{
+    gNotificationManagerStub->identifiedNotify();
+}
+
+void ClientIdentifier::getPidReply(QDBusPendingCallWatcher *getPidWatcher)
+{
+    Q_UNUSED(getPidWatcher);
+}
+
+void ClientIdentifier::identifyReply(QDBusPendingCallWatcher *identifyWatcher) {
+    Q_UNUSED(identifyWatcher);
 }
 
 #endif

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -1,6 +1,7 @@
 /***************************************************************************
 **
-** Copyright (c) 2012 Jolla Ltd.
+** Copyright (c) 2012 - 2021 Jolla Ltd.
+** Copyright (c) 2021 Open Mobile Platform LLC.
 **
 ** This file is part of lipstick.
 **
@@ -61,6 +62,31 @@ void NotificationManager::expire()
 
 void NotificationManager::reportModifications()
 {
+}
+
+void NotificationManager::identifiedGetNotifications()
+{
+}
+
+void NotificationManager::identifiedGetNotificationsByCategory()
+{
+}
+
+void NotificationManager::identifiedCloseNotification()
+{
+}
+
+void NotificationManager::identifiedNotify()
+{
+}
+
+void ClientIdentifier::getPidReply(QDBusPendingCallWatcher *getPidWatcher)
+{
+    Q_UNUSED(getPidWatcher);
+}
+
+void ClientIdentifier::identifyReply(QDBusPendingCallWatcher *identifyWatcher) {
+    Q_UNUSED(identifyWatcher);
 }
 
 NotificationManager *notificationManagerInstance = 0;

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
 **
-** Copyright (c) 2012 - 2020 Jolla Ltd.
-** Copyright (c) 2020 Open Mobile Platform LLC.
+** Copyright (c) 2012 - 2021 Jolla Ltd.
+** Copyright (c) 2020 - 2021 Open Mobile Platform LLC.
 **
 ** This file is part of lipstick.
 **
@@ -166,6 +166,31 @@ void NotificationManager::expire()
 
 void NotificationManager::reportModifications()
 {
+}
+
+void NotificationManager::identifiedGetNotifications()
+{
+}
+
+void NotificationManager::identifiedGetNotificationsByCategory()
+{
+}
+
+void NotificationManager::identifiedCloseNotification()
+{
+}
+
+void NotificationManager::identifiedNotify()
+{
+}
+
+void ClientIdentifier::getPidReply(QDBusPendingCallWatcher *getPidWatcher)
+{
+    Q_UNUSED(getPidWatcher);
+}
+
+void ClientIdentifier::identifyReply(QDBusPendingCallWatcher *identifyWatcher) {
+    Q_UNUSED(identifyWatcher);
 }
 
 static int playedFeedbacks()


### PR DESCRIPTION
In case of sandboxed applications GetConnectionUnixProcessID returns
pid of xdg-dbus-proxy process rather than pid of actual client. This
causes notifications to be listed as originating from xdg-dbus-proxy.
Additionally the pid queries are done via synchronous ipc while handling
incoming messages which blocks lipstick mainloop and can cause problems
elsewhere.

Implement a class for handling asynchronous xdg-dbus-proxy aware
client identification, and utilize it for handling all notification
manager D-Bus method calls that require client identification.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>