### PR TITLE
notif: Permit apkd transient notification to use one line

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -488,9 +488,8 @@ uint NotificationManager::handleNotify(int clientPid, const QString &appName, ui
     if (clientPid > 0) {
         // Look up the properties of the originating process
         pidProperties = processProperties(clientPid);
-        // A4 and A8.
-        androidOrigin = (pidProperties.first == QLatin1String("alien_bridge_server") ||
-                         pidProperties.first == QLatin1String("apkd-bridge"));
+        // Only Alien4 has special notification handling
+        androidOrigin = pidProperties.first == QLatin1String("alien_bridge_server");
     }
 
     // Allow notifications originating from android to be differentiated from native app notifications


### PR DESCRIPTION
[notif] Permit apkd transient notification to use one line. JB#57361

If both the preview summary and body are present, all notifications
coming from apkd will not use the smaller single line display. This is
used by apkd-bridge when starting alien to launch an app, recently moved
from the root apkd daemon which wasn't considered an Android notification.