### PR TITLE
Fix ut_notificationmanager. JB#57271

### DIFF
--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -314,7 +314,9 @@ NotificationManager::NotificationManager(QObject *parent, bool owner) :
 NotificationManager::~NotificationManager()
 {
     m_database->commit();
+    QString connectionName = m_database->connectionName();
     delete m_database;
+    QSqlDatabase::removeDatabase(connectionName);
 }
 
 LipstickNotification *NotificationManager::notification(uint id) const


### PR DESCRIPTION
Commit c14ee388fe4 switched from calling MRemoteAction::trigger() to emit a signal that can be handled outside the notificationmanager. Not sure how much this test makes sense anymore, but at least it passes now again.

Also made notificationmanager to also remove the database connection. Cleans up test run by not complaining on duplicate connection for each test.

@Tomin1 @spiiroin 