### PR TITLE
[lipstick] Require nemo-qml-plugin-systemsettings >= 0.8.0. JB#56948

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -38,7 +38,7 @@ BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(wayland-server)
 BuildRequires:  pkgconfig(usb-moded-qt5) >= 1.8
-BuildRequires:  pkgconfig(systemsettings) >= 0.5.73
+BuildRequires:  pkgconfig(systemsettings) >= 0.8.0
 BuildRequires:  pkgconfig(nemodevicelock)
 BuildRequires:  pkgconfig(sailfishusermanager)
 BuildRequires:  pkgconfig(glib-2.0)
@@ -47,7 +47,7 @@ BuildRequires:  qt5-qtgui-devel >= 5.2.1+git24
 BuildRequires:  qt5-qtwayland-wayland_egl-devel >= 5.4.0+git26
 BuildRequires:  doxygen
 BuildRequires:  qt5-qttools-qthelp-devel
-BuildRequires:  nemo-qml-plugin-systemsettings >= 0.5.73
+BuildRequires:  nemo-qml-plugin-systemsettings >= 0.8.0
 
 %description
 A QML toolkit for homescreen creation


### PR DESCRIPTION
Older versions of systemsettings plugin headers still have
AboutSettings::imei() present and that causes compilation
failures in lipstick side moc generated code.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>