### PR TITLE
Add Discord to androidnotificationpriorities

### DIFF
--- a/src/androidnotificationpriorities
+++ b/src/androidnotificationpriorities
@@ -57,3 +57,6 @@ package:com.microsoft.teams;chat,chat_exists
 
 Messenger Lite;chat,chat_exists
 package:com.facebook.mlite;chat,chat_exists
+
+Discord;chat,chat_exists
+package:com.discord;chat,chat_exists


### PR DESCRIPTION
Discord is one of the most popular chat apps right now, this makes the notifications work as they should be.