### PR TITLE
[lipstick] Support also X-DBusActivatable. Fixes JB#57377

### DIFF
--- a/src/components/launcheritem.h
+++ b/src/components/launcheritem.h
@@ -94,6 +94,7 @@ public:
     bool isValid() const;
     bool isLaunching() const;
     bool isStillValid();
+    bool dBusActivatable() const;
     bool dBusActivated() const;
     MRemoteAction remoteAction(const QStringList &arguments = QStringList()) const;
 


### PR DESCRIPTION
Since we need to support desktop file names that don't conform to
reverse-DNS notation, allow an alternative name for DBusActivatable with
"X-" prefix. Both of them behave the same, but this new prefixed version
can be used with desktop-file-install.