### PR TITLE
[lipstick] Suppress charging warnings when charging is disabled. Fixes JB#58812

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -27,7 +27,7 @@ BuildRequires:  pkgconfig(Qt5Sensors)
 BuildRequires:  pkgconfig(contentaction5)
 BuildRequires:  pkgconfig(mlite5) >= 0.2.19
 BuildRequires:  pkgconfig(mce) >= 1.22.0
-BuildRequires:  pkgconfig(mce-qt5) >= 1.4.0
+BuildRequires:  pkgconfig(mce-qt5) >= 1.5.0
 BuildRequires:  pkgconfig(keepalive)
 BuildRequires:  pkgconfig(dsme_dbus_if) >= 0.63.2
 BuildRequires:  pkgconfig(thermalmanager_dbus_if)

--- a/src/notifications/batterynotifier.h
+++ b/src/notifications/batterynotifier.h
@@ -21,6 +21,7 @@
 #include <QTimer>
 #include <qmcechargertype.h>
 #include <qmcechargerstate.h>
+#include <qmcechargingstate.h>
 #include <qmcebatterystatus.h>
 #include <qmcebatterylevel.h>
 #include <qmcepowersavemode.h>
@@ -56,6 +57,7 @@ private slots:
     void onNotificationClosed(uint id, uint reason);
     void onChargerTypeChanged();
     void onChargerStateChanged();
+    void onChargingStateChanged();
     void onBatteryStatusChanged();
     void onBatteryLevelChanged();
     void onPowerSaveModeChanged();
@@ -90,6 +92,7 @@ private:
     struct State {
         QMceChargerType::Type m_chargerType = QMceChargerType::None;
         bool m_chargerState = false;
+        QMceChargingState::State m_chargingState = QMceChargingState::Unknown;
         QMceBatteryStatus::Status m_batteryStatus = QMceBatteryStatus::Ok;
         int m_batteryLevel = -1;
         int m_minimumBatteryLevel = -1;
@@ -140,6 +143,7 @@ private:
     NotificationManager *m_notificationManager;
     QMceChargerType *m_mceChargerType;
     QMceChargerState *m_mceChargerState;
+    QMceChargingState *m_mceChargingState;
     QMceBatteryStatus *m_mceBatteryStatus;;
     QMceBatteryLevel *m_mceBatteryLevel;
     QMcePowerSaveMode *m_mcePowerSaveMode;


### PR DESCRIPTION
When charging has been disabled for the purpose of limiting charging time and/or cycles, battery level is expected to drop while charger is connected but "Not enough power to charge" warning notifications are still triggered.

Take charging enabled/disabled state into account and suppress warnings while charging is disabled.

QMceChargingState is available in libmce-qt >= 1.5.0

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>