### PR TITLE
[lipstick] Always play custom notification sounds with default feedback. JB#59247

### DIFF
--- a/src/notifications/notificationfeedbackplayer.h
+++ b/src/notifications/notificationfeedbackplayer.h
@@ -35,30 +35,11 @@ namespace Ngf {
 class LIPSTICK_EXPORT NotificationFeedbackPlayer : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(int minimumPriority READ minimumPriority WRITE setMinimumPriority NOTIFY minimumPriorityChanged)
 
 public:
     explicit NotificationFeedbackPlayer(QObject *parent = 0);
 
-    /*!
-     * Returns the minimum priority of notifications for which a feedback should be played
-     *
-     * \return the minimum priority of notifications for which a feedback should be played
-     */
-    int minimumPriority() const;
-
-    /*!
-     * Sets the minimum priority of notifications for which a feedback should be played
-     *
-     * \param minimumPriority the minimum priority of notifications for which a feedback should be played
-     */
-    void setMinimumPriority(int minimumPriority);
-
     bool doNotDisturbMode() const;
-
-signals:
-    //! Emitted when the minimum priority of notifications for which a feedback should be played has changed
-    void minimumPriorityChanged();
 
 private slots:
     //! Initializes the feedback player
@@ -80,16 +61,13 @@ private slots:
 
 private:
     //! Check whether feedbacks should be enabled for the given notification
-    bool isEnabled(LipstickNotification *notification, int minimumPriority);
+    bool isEnabled(LipstickNotification *notification);
 
     //! Non-graphical feedback player
     Ngf::Client *m_ngfClient;
 
     //! A mapping between notification IDs and NGF play IDs.
     QMultiHash<LipstickNotification *, uint> m_idToEventId;
-
-    //! The minimum priority of notifications for which a feedback should be played
-    int m_minimumPriority;
 
     MGConfItem m_doNotDisturbSetting;
     ProfileControl m_profileControl;

--- a/tests/stubs/notificationfeedbackplayer_stub.h
+++ b/tests/stubs/notificationfeedbackplayer_stub.h
@@ -24,8 +24,6 @@ class NotificationFeedbackPlayerStub : public StubBase
 {
 public:
     virtual void NotificationFeedbackPlayerConstructor(QObject *parent);
-    virtual int minimumPriority() const;
-    virtual void setMinimumPriority(int minimumPriority);
     virtual void init();
     virtual void addNotification(uint id);
     virtual void removeNotification(uint id);
@@ -36,18 +34,6 @@ void NotificationFeedbackPlayerStub::NotificationFeedbackPlayerConstructor(QObje
 {
     Q_UNUSED(parent);
 
-}
-int NotificationFeedbackPlayerStub::minimumPriority() const
-{
-    stubMethodEntered("minimumPriority");
-    return stubReturnValue<int>("minimumPriority");
-}
-
-void NotificationFeedbackPlayerStub::setMinimumPriority(int minimumPriority)
-{
-    QList<ParameterBase *> params;
-    params.append( new Parameter<int >(minimumPriority));
-    stubMethodEntered("setMinimumPriority", params);
 }
 
 void NotificationFeedbackPlayerStub::init()
@@ -81,16 +67,6 @@ NotificationFeedbackPlayer::NotificationFeedbackPlayer(QObject *parent)
     : m_doNotDisturbSetting("/lipstick/do_not_disturb")
 {
     gNotificationFeedbackPlayerStub->NotificationFeedbackPlayerConstructor(parent);
-}
-
-int NotificationFeedbackPlayer::minimumPriority() const
-{
-    return gNotificationFeedbackPlayerStub->minimumPriority();
-}
-
-void NotificationFeedbackPlayer::setMinimumPriority(int minimumPriority)
-{
-    gNotificationFeedbackPlayerStub->setMinimumPriority(minimumPriority);
 }
 
 void NotificationFeedbackPlayer::init()

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -191,9 +191,8 @@ void Ut_NotificationFeedbackPlayer::testWithoutFeedbackId()
     notification->setHints(QVariantHash());
     player->addNotification(1);
 
-    // Check that NGFAdapter::play() was called with the default feedback
-    QCOMPARE(gClientStub->stubCallCount("play"), 1);
-    QCOMPARE(gClientStub->stubLastCallTo("play").parameter<QString>(0), QString("default"));
+    // Check that NGFAdapter::play() was not called
+    QCOMPARE(gClientStub->stubCallCount("play"), 0);
 }
 
 void Ut_NotificationFeedbackPlayer::testMultipleFeedbackIds()
@@ -294,12 +293,10 @@ void Ut_NotificationFeedbackPlayer::testUpdateNotification()
     notification->setHints(hints);
     player->addNotification(1);
 
-    QCOMPARE(gClientStub->stubCallCount("play"), 4);
-    QCOMPARE(gClientStub->stubLastCallTo("play").parameter<QString>(0), QString("default"));
+    QCOMPARE(gClientStub->stubCallCount("play"), 3);
 
-    // Check that NGFAdapter::stop() was called again    
-    QCOMPARE(gClientStub->stubCallCount("stop"), 7);
-    QCOMPARE(gClientStub->stubLastCallTo("stop").parameter<QString>(0), QString("default"));
+    // Check that NGFAdapter::stop() was not called again
+    QCOMPARE(gClientStub->stubCallCount("stop"), 6);
 }
 
 void Ut_NotificationFeedbackPlayer::testUpdateNotificationAfterRestart()
@@ -360,35 +357,6 @@ void Ut_NotificationFeedbackPlayer::testNotificationPreviewsDisabled()
     qWaylandSurfaceWindowProperties = windowProperties;
 
     createNotification(1, urgency);
-    player->addNotification(1);
-
-    QCOMPARE(gClientStub->stubCallCount("play"), playCount);
-}
-
-void Ut_NotificationFeedbackPlayer::testNotificationPriority_data()
-{
-    QTest::addColumn<int>("minimumPriority");
-    QTest::addColumn<int>("urgency");
-    QTest::addColumn<QVariant>("priority");
-    QTest::addColumn<int>("playCount");
-
-    QTest::newRow("Minimum priority 50, urgency 1, priority not defined") << 50 << 1 << QVariant() << 0;
-    QTest::newRow("Minimum priority 50, urgency 1, priority 49") << 50 << 1 << QVariant(49) << 0;
-    QTest::newRow("Minimum priority 50, urgency 1, priority 50") << 50 << 1 << QVariant(50) << 1;
-    QTest::newRow("Minimum priority 50, urgency 2, priority not defined") << 50 << 2 << QVariant() << 1;
-    QTest::newRow("Minimum priority 50, urgency 2, priority 49") << 50 << 2 << QVariant(49) << 1;
-    QTest::newRow("Minimum priority 50, urgency 2, priority 50") << 50 << 2 << QVariant(50) << 1;
-}
-
-void Ut_NotificationFeedbackPlayer::testNotificationPriority()
-{
-    QFETCH(int, minimumPriority);
-    QFETCH(int, urgency);
-    QFETCH(QVariant, priority);
-    QFETCH(int, playCount);
-
-    player->setMinimumPriority(minimumPriority);
-    createNotification(1, urgency, priority);
     player->addNotification(1);
 
     QCOMPARE(gClientStub->stubCallCount("play"), playCount);

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.h
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.h
@@ -40,8 +40,6 @@ private slots:
     void testUpdateNotificationAfterRestart();
     void testNotificationPreviewsDisabled_data();
     void testNotificationPreviewsDisabled();
-    void testNotificationPriority_data();
-    void testNotificationPriority();
 
 private:
     NotificationFeedbackPlayer *player;


### PR DESCRIPTION
The notifications might include a custom feedback either directly or indirectly via a notification category. That had a chance of ending up played wrong since the default ngf event has proper setup for the sound volumes etc. Also curiously earlier the custom sound was played on all the feedback items. Now using the "default" only if needed for custom sounds or such.

Removed the minimum priority API to make this simpler. The custom priority property (note that urgency is different) has been phasing out anyhow and didn't find too good reasons to keep it here.

@jusa @abranson @llewelld 