### PR TITLE
[lipstick] Allow to remove notification feedback on qml api. JB#59267

### DIFF
--- a/src/notifications/notificationfeedbackplayer.h
+++ b/src/notifications/notificationfeedbackplayer.h
@@ -41,6 +41,14 @@ public:
 
     bool doNotDisturbMode() const;
 
+public slots:
+    /*!
+     * Removes the notification with the given ID.
+     *
+     * \param id the ID of the notification to be removed
+     */
+    void removeNotification(uint id);
+
 private slots:
     //! Initializes the feedback player
     void init();
@@ -51,13 +59,6 @@ private slots:
      * \param id the ID of the notification to be added
      */
     void addNotification(uint id);
-
-    /*!
-     * Removes the notification with the given ID.
-     *
-     * \param id the ID of the notification to be removed
-     */
-    void removeNotification(uint id);
 
 private:
     //! Check whether feedbacks should be enabled for the given notification


### PR DESCRIPTION
Can be used when the notification is acknowledged enough, not requiring to really close the notification to get rid of a long feedback.

@abranson @llewelld 