### PR TITLE
[lipstick] Fix volumecontrol unit test. JB#59248

### DIFF
--- a/tests/ut_volumecontrol/ut_volumecontrol.cpp
+++ b/tests/ut_volumecontrol/ut_volumecontrol.cpp
@@ -99,7 +99,7 @@ void Ut_VolumeControl::init()
 {
     gPulseAudioControlStub->stubReset();
 
-    volumeControl = new VolumeControl;
+    volumeControl = new VolumeControl(true);
     volumeControl->setVolume(5, 10);
 }
 


### PR DESCRIPTION
Commit 80f6d8f0 made the volumecontrol hardware handling to be explicitly enabled. Doing so as the test expects it.

@rainemak @llewelld 