### PR TITLE
[lipstick] Do not change signal handlers on shutdown. JB#60078

### DIFF
--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -210,27 +210,10 @@ void HomeApplication::setUpSignalHandlers()
     action.sa_flags = 0;
     action.sa_flags |= SA_RESTART;
 
-    if (sigaction(SIGINT, &action, &m_originalSigIntAction))
+    if (sigaction(SIGINT, &action, nullptr))
         qFatal("Failed to set up SIGINT handling");
-    if (sigaction(SIGTERM, &action, &m_originalSigTermAction))
+    if (sigaction(SIGTERM, &action, nullptr))
         qFatal("Failed to set up SIGTERM handling");
-}
-
-void HomeApplication::restoreSignalHandlers()
-{
-    if (s_quitSignalFd == -1) {
-        qWarning() << "HomeApplication::restoreSignalHandlers: called multiple times?";
-        return;
-    }
-
-    if (sigaction(SIGINT, &m_originalSigIntAction, nullptr))
-        qFatal("Failed to restore original SIGINT handling");
-    if (sigaction(SIGTERM, &m_originalSigTermAction, nullptr))
-        qFatal("Failed to restore original SIGTERM handling");
-
-    delete m_quitSignalNotifier, m_quitSignalNotifier = nullptr;
-
-    ::close(s_quitSignalFd), s_quitSignalFd = -1;
 }
 
 void HomeApplication::sendHomeReadySignalIfNotAlreadySent()

--- a/src/homeapplication.h
+++ b/src/homeapplication.h
@@ -88,11 +88,6 @@ public:
     void setCompositorPath(const QString &path);
 
     /*!
-     * Restores any installed signal handlers.
-     */
-    void restoreSignalHandlers();
-
-    /*!
      * Gets the home active flag.
      */
     bool homeActive() const;
@@ -157,10 +152,6 @@ private:
     static int s_quitSignalFd;
     //! Socket notifier for signal handling
     QSocketNotifier *m_quitSignalNotifier;
-    //! The original SIGINT action
-    struct sigaction m_originalSigIntAction;
-    //! The original SIGTERM action
-    struct sigaction m_originalSigTermAction;
 
     HomeWindow *m_mainWindowInstance;
     QString m_qmlPath;

--- a/src/shutdownscreen.cpp
+++ b/src/shutdownscreen.cpp
@@ -76,8 +76,6 @@ void ShutdownScreen::applySystemState(DeviceState::DeviceState::StateIndication 
 {
     switch (what) {
         case DeviceState::DeviceState::Shutdown:
-            // To avoid early quitting on shutdown
-            HomeApplication::instance()->restoreSignalHandlers();
             setWindowVisible(true);
             break;
 

--- a/tests/ut_shutdownscreen/ut_shutdownscreen.cpp
+++ b/tests/ut_shutdownscreen/ut_shutdownscreen.cpp
@@ -50,12 +50,6 @@ HomeApplication *HomeApplication::instance()
     return 0;
 }
 
-bool signalHandlersRestored = false;
-void HomeApplication::restoreSignalHandlers()
-{
-    signalHandlersRestored = true;
-}
-
 int argc = 1;
 char *argv[] = { (char *) "./ut_shutdownscreen", NULL };
 

--- a/tests/ut_thermalnotifier/ut_thermalnotifier.cpp
+++ b/tests/ut_thermalnotifier/ut_thermalnotifier.cpp
@@ -31,10 +31,6 @@ HomeApplication *HomeApplication::instance()
     return 0;
 }
 
-void HomeApplication::restoreSignalHandlers()
-{
-}
-
 int argc = 1;
 char *argv[] = { (char *) "./ut_thermalnotifier", NULL };
 


### PR DESCRIPTION
Getting a shutdown notification basically means that we are going to get a TERM signal in a couple of seconds. Using that as a cue for substituting TERM handler that triggers lipstick to make a clean exit with something else makes little sense. Especially as the candidates are async-signal unsafe code from hwcomposer-plugin (that can hang and require KILL) or default handler that makes quick and dirty exit (potentially leaving behind e.g. lock files).

Keep using the already installed lipstick signal handlers.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>