### PR TITLE
Notification text action support. JB#55557

### DIFF
--- a/src/notifications/lipsticknotification.cpp
+++ b/src/notifications/lipsticknotification.cpp
@@ -44,6 +44,7 @@ const char *LipstickNotification::HINT_PREVIEW_SUMMARY = "x-nemo-preview-summary
 const char *LipstickNotification::HINT_SUB_TEXT = "x-nemo-sub-text";
 const char *LipstickNotification::HINT_REMOTE_ACTION_PREFIX = "x-nemo-remote-action-";
 const char *LipstickNotification::HINT_REMOTE_ACTION_ICON_PREFIX = "x-nemo-remote-action-icon-";
+const char *LipstickNotification::HINT_REMOTE_ACTION_TYPE_PREFIX = "x-nemo-remote-action-type-";
 const char *LipstickNotification::HINT_USER_REMOVABLE = "x-nemo-user-removable";
 const char *LipstickNotification::HINT_FEEDBACK = "x-nemo-feedback";
 const char *LipstickNotification::HINT_DISPLAY_ON = "x-nemo-display-on";
@@ -393,14 +394,16 @@ QVariantList LipstickNotification::remoteActions() const
             vm.insert(QStringLiteral("displayName"), displayName);
         }
 
+        const QString icon(m_hints.value(LipstickNotification::HINT_REMOTE_ACTION_ICON_PREFIX + name).toString());
+        if (!icon.isEmpty()) {
+            vm.insert(QStringLiteral("icon"), icon);
+        }
+
+        const QString type(m_hints.value(LipstickNotification::HINT_REMOTE_ACTION_TYPE_PREFIX + name).toString());
+        vm.insert(QStringLiteral("type"), type);
+
         const QString hint(m_hints.value(LipstickNotification::HINT_REMOTE_ACTION_PREFIX + name).toString());
         if (!hint.isEmpty()) {
-            const QString icon(m_hints.value(LipstickNotification::HINT_REMOTE_ACTION_ICON_PREFIX + name).toString());
-
-            if (!icon.isEmpty()) {
-                vm.insert(QStringLiteral("icon"), icon);
-            }
-
             // Extract the element of the DBus call
             QStringList elements(hint.split(' ', QString::SkipEmptyParts));
             if (elements.size() <= 3) {
@@ -510,7 +513,8 @@ void LipstickNotification::updateHintValues()
             hint.compare(LipstickNotification::HINT_OWNER, Qt::CaseInsensitive) != 0 &&
             hint.compare(LipstickNotification::HINT_PROGRESS, Qt::CaseInsensitive) &&
             !hint.startsWith(LipstickNotification::HINT_REMOTE_ACTION_PREFIX, Qt::CaseInsensitive) &&
-            !hint.startsWith(LipstickNotification::HINT_REMOTE_ACTION_ICON_PREFIX, Qt::CaseInsensitive)) {
+            !hint.startsWith(LipstickNotification::HINT_REMOTE_ACTION_ICON_PREFIX, Qt::CaseInsensitive) &&
+            !hint.startsWith(LipstickNotification::HINT_REMOTE_ACTION_TYPE_PREFIX, Qt::CaseInsensitive)) {
             m_hintValues.insert(hint, it.value());
         }
     }

--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -113,6 +113,9 @@ public:
     //! Nemo hint: Icon for the remote action of the notification. Prefix only: the action identifier is to be appended.
     static const char *HINT_REMOTE_ACTION_ICON_PREFIX;
 
+    //! Nemo hint: Optional type for the remote action of the notification. Prefix only: the action identifier is to be appended.
+    static const char *HINT_REMOTE_ACTION_TYPE_PREFIX;
+
     //! Nemo hint: User removability of the notification.
     static const char *HINT_USER_REMOVABLE;
 

--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -294,8 +294,9 @@ signals:
      * Sent when an action defined for the notification is invoked.
      *
      * \param action the action that was invoked
+     * \param actionText parameter for the action
      */
-    void actionInvoked(QString action);
+    void actionInvoked(QString action, QString actionText);
 
     //! Sent when the removal of this notification was requested.
     void removeRequested();

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -482,7 +482,6 @@ uint NotificationManager::handleNotify(int clientPid, const QString &appName, ui
         }
     }
 
-
     QPair<QString, QString> pidProperties;
     bool androidOrigin(false);
     if (clientPid > 0) {

--- a/src/notifications/notificationmanager.h
+++ b/src/notifications/notificationmanager.h
@@ -240,6 +240,7 @@ signals:
     void notificationsRemoved(const QList<uint> &ids);
 
     void remoteActionActivated(const QString &remoteAction);
+    void remoteTextActionActivated(const QString &remoteAction, const QString &text);
 
 public slots:
     /*!
@@ -292,10 +293,8 @@ private slots:
     /*!
      * Invokes the given action if it is has been defined. The
      * sender is expected to be a Notification.
-     *
-     * \param action the action to be invoked
      */
-    void invokeAction(const QString &action);
+    void invokeAction(const QString &action, const QString &actionText);
 
     /*!
      * Removes a notification if it is removable by the user.

--- a/tests/stubs/notificationmanager_stub.h
+++ b/tests/stubs/notificationmanager_stub.h
@@ -37,7 +37,7 @@ public:
     virtual void removeNotificationsWithCategory(const QString &category);
     virtual void updateNotificationsWithCategory(const QString &category);
     virtual void commit();
-    virtual void invokeAction(const QString &action);
+    virtual void invokeAction(const QString &action, const QString &actionText);
     virtual void removeNotificationIfUserRemovable(uint id);
     virtual void removeUserRemovableNotifications();
     virtual void expire();
@@ -154,10 +154,11 @@ void NotificationManagerStub::commit()
     stubMethodEntered("commit");
 }
 
-void NotificationManagerStub::invokeAction(const QString &action)
+void NotificationManagerStub::invokeAction(const QString &action, const QString &actionText)
 {
     QList<ParameterBase *> params;
     params.append( new Parameter<QString >(action));
+    params.append( new Parameter<QString >(actionText));
     stubMethodEntered("invokeAction", params);
 }
 
@@ -284,9 +285,9 @@ void NotificationManager::commit()
     gNotificationManagerStub->commit();
 }
 
-void NotificationManager::invokeAction(const QString &action)
+void NotificationManager::invokeAction(const QString &action, const QString &actionText)
 {
-    gNotificationManagerStub->invokeAction(action);
+    gNotificationManagerStub->invokeAction(action, actionText);
 }
 
 void NotificationManager::removeNotificationIfUserRemovable(uint id)

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -32,7 +32,7 @@ NotificationManager::~NotificationManager()
 {
 }
 
-void NotificationManager::invokeAction(const QString &)
+void NotificationManager::invokeAction(const QString &, const QString &)
 {
 }
 

--- a/tests/ut_notificationmanager/ut_notificationmanager.h
+++ b/tests/ut_notificationmanager/ut_notificationmanager.h
@@ -39,7 +39,7 @@ private slots:
     void testImmediateExpiration();
 
 signals:
-    void actionInvoked(QString action);
+    void actionInvoked(QString action, QString actionText = QString());
     void removeRequested();
 };
 

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -109,7 +109,7 @@ NotificationManager::~NotificationManager()
 {
 }
 
-void NotificationManager::invokeAction(const QString &)
+void NotificationManager::invokeAction(const QString &, const QString &)
 {
 }
 


### PR DESCRIPTION
Started here with PR #11 but the input map handling was broken, handling that properly didn't seem to go along nice and the usage on notification plugin side didn't feel entirely good. So instead moved to a simpler way with https://github.com/sailfishos/nemo-qml-plugin-notifications/pull/9 . Think that should be good enough to get this moving forward now.

