### PR TITLE
Add default argument to actionInvoked actionText. JB#55557

### DIFF
--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -296,7 +296,7 @@ signals:
      * \param action the action that was invoked
      * \param actionText parameter for the action
      */
-    void actionInvoked(QString action, QString actionText);
+    void actionInvoked(QString action, QString actionText = QString());
 
     //! Sent when the removal of this notification was requested.
     void removeRequested();


### PR DESCRIPTION
Fixes regression:
https://github.com/sailfishos/lipstick/pull/41#issuecomment-1612784777

Avoids breaking uses that aren't aware of the new argument. Fixes default actions in notifications.