### PR TITLE
[lipstick] Don't keep restored state on updated notifications. JB#61050

### DIFF
--- a/src/notifications/lipsticknotification.cpp
+++ b/src/notifications/lipsticknotification.cpp
@@ -50,7 +50,6 @@ const char *LipstickNotification::HINT_FEEDBACK = "x-nemo-feedback";
 const char *LipstickNotification::HINT_DISPLAY_ON = "x-nemo-display-on";
 const char *LipstickNotification::HINT_ORIGIN_PACKAGE = "x-nemo-origin-package";
 const char *LipstickNotification::HINT_OWNER = "x-nemo-owner";
-const char *LipstickNotification::HINT_RESTORED = "x-nemo-restored";
 const char *LipstickNotification::HINT_PROGRESS = "x-nemo-progress";
 const char *LipstickNotification::HINT_VIBRA = "x-nemo-vibrate";
 const char *LipstickNotification::HINT_VISIBILITY = "x-nemo-visibility";
@@ -442,7 +441,12 @@ QString LipstickNotification::owner() const
 
 bool LipstickNotification::restored() const
 {
-    return m_hints.value(LipstickNotification::HINT_RESTORED).toBool();
+    return m_restored;
+}
+
+void LipstickNotification::setRestored(bool restored)
+{
+    m_restored = restored;
 }
 
 qreal LipstickNotification::progress() const

--- a/src/notifications/lipsticknotification.h
+++ b/src/notifications/lipsticknotification.h
@@ -131,10 +131,6 @@ public:
     //! Nemo hint: Indicates the identifer of the owner for notification
     static const char *HINT_OWNER;
 
-    //! Nemo hint: Indicates that this notification has been restored from persistent storage since the last update.
-    //! Internal, shouldn't be expected or allowed from d-bus
-    static const char *HINT_RESTORED;
-
     //! Nemo hint: progress percentage between 0 and 1, negative for indeterminate
     static const char *HINT_PROGRESS;
 
@@ -265,6 +261,7 @@ public:
 
     //! Returns true if the notification has been restored since it was last modified
     bool restored() const;
+    void setRestored(bool restored);
 
     qreal progress() const;
 
@@ -376,6 +373,7 @@ private:
     //! Hints for the notification
     QVariantHash m_hints;
     QVariantMap m_hintValues;
+    bool m_restored = false;
 
     //! Expiration timeout for the notification
     int m_expireTimeout;

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -531,6 +531,7 @@ uint NotificationManager::handleNotify(int clientPid, const QString &appName, ui
         notification->setActions(notificationData.actions());
         notification->setHints(notificationData.hints());
         notification->setExpireTimeout(notificationData.expireTimeout());
+        notification->setRestored(false);
     } else {
         notification = new LipstickNotification(notificationData);
         notification->setParent(this);
@@ -868,9 +869,7 @@ void NotificationManager::updateNotificationsWithCategory(const QString &categor
 
     foreach (LipstickNotification *notification, categoryNotifications) {
         // Mark the notification as restored to avoid showing the preview banner again
-        QVariantHash hints = notification->hints();
-        hints.insert(LipstickNotification::HINT_RESTORED, true);
-        notification->setHints(hints);
+        notification->setRestored(true);
 
         // Update the category properties and re-publish
         applyCategoryDefinition(notification);
@@ -1260,9 +1259,6 @@ void NotificationManager::fetchData(bool update)
                                 << notificationHints << expireTimeout << "->" << id);
             transientIds.append(id);
             continue;
-        } else {
-            // Mark this notification as restored
-            notificationHints.insert(LipstickNotification::HINT_RESTORED, true);
         }
 
         bool expired = false;
@@ -1280,6 +1276,7 @@ void NotificationManager::fetchData(bool update)
                                                                       id, QString(), summary, body, notificationActions,
                                                                       notificationHints, expireTimeout, this);
         notification->setAppIcon(appIcon, appIconOrigin);
+        notification->setRestored(true);
         m_notifications.insert(id, notification);
 
         if (id > m_previousNotificationID) {

--- a/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
+++ b/tests/ut_notificationfeedbackplayer/ut_notificationfeedbackplayer.cpp
@@ -305,9 +305,7 @@ void Ut_NotificationFeedbackPlayer::testUpdateNotificationAfterRestart()
     LipstickNotification *notification = createNotification(1);
 
     // Mark the notification as restored from storage
-    QVariantHash hints;
-    hints.insert(LipstickNotification::HINT_RESTORED, true);
-    notification->setHints(hints);
+    notification->setRestored(true);
 
     // Update the notification
     player->addNotification(1);

--- a/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
+++ b/tests/ut_notificationpreviewpresenter/ut_notificationpreviewpresenter.cpp
@@ -428,8 +428,8 @@ void Ut_NotificationPreviewPresenter::testNotificationNotShownIfRestored()
     QVariantHash hints;
     hints.insert(LipstickNotification::HINT_PREVIEW_SUMMARY, "previewSummary");
     hints.insert(LipstickNotification::HINT_PREVIEW_BODY, "previewBody");
-    hints.insert(LipstickNotification::HINT_RESTORED, true);
     LipstickNotification *notification = new LipstickNotification("ut_notificationpreviewpresenter", "", "", 1, "", "", "", QStringList(), hints, -1);
+    notification->setRestored(true);
     notificationManagerNotification.insert(1, notification);
     presenter.updateNotification(1);
 


### PR DESCRIPTION
If an application was fetching notifications via GetNotifications(), only updating some properties, and then triggering an update, it was possible that the internal x-nemo-restored hint leaked to the application side and came back on the update, skipping feedbacks and notification popup on the update. And then finally being even saved on the notification database.

So let's once and for all make this restored status an internal detail of the lipstick notification class.