### PR TITLE
[lipstick] Avoid turning display on when charging is done. JB#61400

### DIFF
--- a/src/notifications/batterynotifier.cpp
+++ b/src/notifications/batterynotifier.cpp
@@ -489,7 +489,9 @@ void BatteryNotifier::sendNotification(BatteryNotifier::NotificationType type)
         hints.insert(LipstickNotification::HINT_FEEDBACK, info.feedback);
     }
     hints.insert(LipstickNotification::HINT_VISIBILITY, QLatin1String("public"));
-    hints.insert(LipstickNotification::HINT_URGENCY, LipstickNotification::Critical);
+    hints.insert(LipstickNotification::HINT_URGENCY,
+                 type == NotificationChargingComplete ? LipstickNotification::Normal
+                                                      : LipstickNotification::Critical);
     hints.insert(LipstickNotification::HINT_TRANSIENT, true);
     QueuedNotification queuedNotification;
     queuedNotification.m_type = type;


### PR DESCRIPTION
Charging started or stopped because usb (dis)connected is good for user to get confirmation by turning on the display with a critical urgency notification, but charging done is more of distraction. Thus lowering the urgency of that case.