### PR TITLE
Fix egrep warnings. JB#61658

### DIFF
--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -33,7 +33,6 @@ OTHER_FILES += \
 QMAKE_CXXFLAGS += \
     -Werror \
     -g \
-    -std=c++0x \
     -fPIC \
     -fvisibility=hidden \
     -fvisibility-inlines-hidden

--- a/tests/common.pri
+++ b/tests/common.pri
@@ -23,11 +23,7 @@ PKGCONFIG += mlite5 systemsettings
 
 QMAKE_CXXFLAGS += \
     -Werror \
-    -g \
-    -std=c++0x \
-    -fPIC \
-    -fvisibility=hidden \
-    -fvisibility-inlines-hidden
+    -g
 
 target.path = /opt/tests/lipstick-tests
 INSTALLS += target

--- a/tests/gen-tests-xml.sh
+++ b/tests/gen-tests-xml.sh
@@ -14,7 +14,7 @@ do
       </case>
       "
 
-		if [ -n "`echo $TEST | egrep '^u'`" ]
+		if [ -n "`echo $TEST | grep -E '^u'`" ]
 		then
 			UT_TESTCASES="${UT_TESTCASES}${TESTCASE_TEMPLATE}"
 		else

--- a/tools/notificationtool/notificationtool.pro
+++ b/tools/notificationtool/notificationtool.pro
@@ -23,7 +23,4 @@ SOURCES += \
 
 QMAKE_CXXFLAGS += \
     -Werror \
-    -g \
-    -std=c++0x \
-    -fvisibility=hidden \
-    -fvisibility-inlines-hidden
+    -g


### PR DESCRIPTION
Egrep is now complaining on being obsolescent so replace that with grep -E.

Removed some pointless compiler flags too.