### PR TITLE
[lipstick] Remove unnecessary Qt5Xml dependency. JB#61735

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -20,7 +20,6 @@ Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Quick) >= 5.2.1
-BuildRequires:  pkgconfig(Qt5Xml)
 BuildRequires:  pkgconfig(Qt5Sql)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(Qt5Sensors)

--- a/src/src.pro
+++ b/src/src.pro
@@ -157,7 +157,7 @@ packagesExist(contentaction5) {
     warning("contentaction doesn't exist; falling back to exec - this may not work so great")
 }
 
-QT += dbus xml qml quick sql gui gui-private sensors
+QT += dbus qml quick sql gui gui-private sensors
 
 QMAKE_CXXFLAGS += \
     -Wfatal-errors \


### PR DESCRIPTION
No QDom* classes used here.