### PR TITLE
Protect screen pointer

### DIFF
--- a/plugin/lipstickplugin.cpp
+++ b/plugin/lipstickplugin.cpp
@@ -57,19 +57,27 @@ void LipstickPlugin::registerTypes(const char *uri)
     qmlRegisterType<LauncherFolderItem>("org.nemomobile.lipstick", 0, 1, "LauncherFolderItem");
     qmlRegisterType<VolumeControl>("org.nemomobile.lipstick", 0, 1, "VolumeControl");
 
-    qmlRegisterUncreatableType<NotificationPreviewPresenter>("org.nemomobile.lipstick", 0, 1, "NotificationPreviewPresenter", "This type is initialized by HomeApplication");
-    qmlRegisterUncreatableType<NotificationFeedbackPlayer>("org.nemomobile.lipstick", 0, 1, "NotificationFeedbackPlayer", "This type is initialized by HomeApplication");
-    qmlRegisterUncreatableType<USBModeSelector>("org.nemomobile.lipstick", 0, 1, "USBModeSelector", "This type is initialized by HomeApplication");
-    qmlRegisterUncreatableType<ShutdownScreen>("org.nemomobile.lipstick", 0, 1, "ShutdownScreen", "This type is initialized by HomeApplication");
+    qmlRegisterUncreatableType<NotificationPreviewPresenter>("org.nemomobile.lipstick", 0, 1,
+                                                             "NotificationPreviewPresenter",
+                                                             "This type is initialized by HomeApplication");
+    qmlRegisterUncreatableType<NotificationFeedbackPlayer>("org.nemomobile.lipstick", 0, 1,
+                                                           "NotificationFeedbackPlayer",
+                                                           "This type is initialized by HomeApplication");
+    qmlRegisterUncreatableType<USBModeSelector>("org.nemomobile.lipstick", 0, 1, "USBModeSelector",
+                                                "This type is initialized by HomeApplication");
+    qmlRegisterUncreatableType<ShutdownScreen>("org.nemomobile.lipstick", 0, 1, "ShutdownScreen",
+                                               "This type is initialized by HomeApplication");
 
     qmlRegisterType<LipstickKeymap>("org.nemomobile.lipstick", 0, 1, "Keymap");
     qmlRegisterType<LipstickCompositor>("org.nemomobile.lipstick", 0, 1, "Compositor");
-    qmlRegisterUncreatableType<QWaylandSurface>("org.nemomobile.lipstick", 0, 1, "WaylandSurface", "This type is created by the compositor");
+    qmlRegisterUncreatableType<QWaylandSurface>("org.nemomobile.lipstick", 0, 1, "WaylandSurface",
+                                                "This type is created by the compositor");
     qmlRegisterType<WindowModel>("org.nemomobile.lipstick", 0, 1, "WindowModel");
     qmlRegisterType<WindowPixmapItem>("org.nemomobile.lipstick", 0, 1, "WindowPixmapItem");
     qmlRegisterType<WindowProperty>("org.nemomobile.lipstick", 0, 1, "WindowProperty");
     qmlRegisterSingletonType<LipstickApi>("org.nemomobile.lipstick", 0, 1, "Lipstick", lipstickApi_callback);
-    qmlRegisterUncreatableType<ScreenshotResult>("org.nemomobile.lipstick", 0, 1, "ScreenshotResult", "This type is initialized by LipstickApi");
+    qmlRegisterUncreatableType<ScreenshotResult>("org.nemomobile.lipstick", 0, 1, "ScreenshotResult",
+                                                 "This type is initialized by LipstickApi");
 
     qmlRegisterType<LipstickCompositorWindow>();
     qmlRegisterType<QObjectListModel>();

--- a/plugin/lipstickplugin.h
+++ b/plugin/lipstickplugin.h
@@ -29,8 +29,8 @@ class Q_DECL_EXPORT LipstickPlugin : public QQmlExtensionPlugin
 
 public:
     explicit LipstickPlugin(QObject *parent = 0);
+
     void registerTypes(const char *uri);
-    
 };
 
 class LauncherModelType : public LauncherModel, public QQmlParserStatus

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -95,7 +95,8 @@ LipstickCompositor::LipstickCompositor()
     setRetainedSelectionEnabled(true);
     addDefaultShell();
 
-    if (m_instance) qFatal("LipstickCompositor: Only one compositor instance per process is supported");
+    if (m_instance)
+        qFatal("LipstickCompositor: Only one compositor instance per process is supported");
     m_instance = this;
 
     m_orientationLock = new MGConfItem("/lipstick/orientationLock", this);

--- a/src/devicestate/devicestate.cpp
+++ b/src/devicestate/devicestate.cpp
@@ -46,8 +46,9 @@
 namespace DeviceState {
 
 DeviceState::DeviceState(QObject *parent)
-             : QObject(parent)
-             , d_ptr(new DeviceStatePrivate) {
+    : QObject(parent)
+    , d_ptr(new DeviceStatePrivate)
+{
     Q_D(DeviceState);
 
     connect(d, SIGNAL(systemStateChanged(DeviceState::DeviceState::StateIndication)),
@@ -56,7 +57,8 @@ DeviceState::DeviceState(QObject *parent)
             this, SIGNAL(nextUserChanged(uint)));
 }
 
-DeviceState::~DeviceState() {
+DeviceState::~DeviceState()
+{
     Q_D(DeviceState);
 
     disconnect(d, SIGNAL(systemStateChanged(DeviceState::DeviceState::StateIndication)),
@@ -67,7 +69,8 @@ DeviceState::~DeviceState() {
     delete d_ptr;
 }
 
-void DeviceState::connectNotify(const QMetaMethod &signal) {
+void DeviceState::connectNotify(const QMetaMethod &signal)
+{
     Q_D(DeviceState);
 
     /* QObject::connect() needs to be thread-safe */
@@ -127,7 +130,8 @@ void DeviceState::connectNotify(const QMetaMethod &signal) {
     }
 }
 
-void DeviceState::disconnectNotify(const QMetaMethod &signal) {
+void DeviceState::disconnectNotify(const QMetaMethod &signal)
+{
     Q_D(DeviceState);
 
     /* QObject::disconnect() needs to be thread-safe */

--- a/src/devicestate/displaystate.cpp
+++ b/src/devicestate/displaystate.cpp
@@ -39,15 +39,17 @@
 namespace DeviceState {
 
 DisplayStateMonitor::DisplayStateMonitor(QObject *parent)
-              : QObject(parent)
-              , d_ptr(new DisplayStateMonitorPrivate) {
+    : QObject(parent)
+    , d_ptr(new DisplayStateMonitorPrivate)
+{
     Q_D(DisplayStateMonitor);
 
     connect(d, SIGNAL(displayStateChanged(DeviceState::DisplayStateMonitor::DisplayState)),
             this, SIGNAL(displayStateChanged(DeviceState::DisplayStateMonitor::DisplayState)));
 }
 
-DisplayStateMonitor::~DisplayStateMonitor() {
+DisplayStateMonitor::~DisplayStateMonitor()
+{
     Q_D(DisplayStateMonitor);
 
     disconnect(d, SIGNAL(displayStateChanged(DeviceState::DisplayStateMonitor::DisplayState)),
@@ -56,7 +58,8 @@ DisplayStateMonitor::~DisplayStateMonitor() {
     delete d_ptr;
 }
 
-void DisplayStateMonitor::connectNotify(const QMetaMethod &signal) {
+void DisplayStateMonitor::connectNotify(const QMetaMethod &signal)
+{
     Q_D(DisplayStateMonitor);
 
     /* QObject::connect() needs to be thread-safe */
@@ -81,7 +84,8 @@ void DisplayStateMonitor::connectNotify(const QMetaMethod &signal) {
     }
 }
 
-void DisplayStateMonitor::disconnectNotify(const QMetaMethod &signal) {
+void DisplayStateMonitor::disconnectNotify(const QMetaMethod &signal)
+{
     Q_D(DisplayStateMonitor);
 
     /* QObject::disconnect() needs to be thread-safe */
@@ -101,11 +105,13 @@ void DisplayStateMonitor::disconnectNotify(const QMetaMethod &signal) {
     }
 }
 
-DisplayStateMonitor::DisplayState DisplayStateMonitor::get() const {
+DisplayStateMonitor::DisplayState DisplayStateMonitor::get() const
+{
     DisplayStateMonitor::DisplayState state = Unknown;
-    QDBusReply<QString> displayStateReply = QDBusConnection::systemBus().call(
-                                                QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF,
-                                                                               MCE_DISPLAY_STATUS_GET));
+    QDBusReply<QString> displayStateReply
+            = QDBusConnection::systemBus().call(
+                QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF,
+                                               MCE_DISPLAY_STATUS_GET));
     if (!displayStateReply.isValid()) {
         return state;
     }
@@ -122,7 +128,8 @@ DisplayStateMonitor::DisplayState DisplayStateMonitor::get() const {
     return state;
 }
 
-bool DisplayStateMonitor::set(DisplayStateMonitor::DisplayState state) {
+bool DisplayStateMonitor::set(DisplayStateMonitor::DisplayState state)
+{
     QString method;
 
     switch (state) {
@@ -139,9 +146,11 @@ bool DisplayStateMonitor::set(DisplayStateMonitor::DisplayState state) {
             return false;
     }
 
-    QDBusMessage displayStateSetCall = QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF, method);
-    (void)QDBusConnection::systemBus().call(displayStateSetCall, QDBus::NoBlock);
+    QDBusMessage displayStateSetCall
+            = QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF, method);
+    QDBusConnection::systemBus().call(displayStateSetCall, QDBus::NoBlock);
+
     return true;
 }
 
-} //DeviceState namespace
+}

--- a/src/devicestate/displaystate.h
+++ b/src/devicestate/displaystate.h
@@ -56,8 +56,7 @@ class DisplayStateMonitor : public QObject
 
 public:
     //! Possible states for device display
-    enum DisplayState
-    {
+    enum DisplayState {
         Off = -1,   //!< Display is off
         Dimmed = 0, //!< Display is dimmed
         On = 1,      //!< Display is on

--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -164,7 +164,10 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     registerVpnAgent();
 
     // Setting up the context and engine things
-    m_qmlEngine->rootContext()->setContextProperty("initialSize", QGuiApplication::primaryScreen()->size());
+    m_qmlEngine->rootContext()->setContextProperty("initialSize",
+                                                   QGuiApplication::primaryScreen()
+                                                   ? QGuiApplication::primaryScreen()->size()
+                                                   : QSize());
     m_qmlEngine->rootContext()->setContextProperty("lipstickSettings", LipstickSettings::instance());
     m_qmlEngine->rootContext()->setContextProperty("LipstickSettings", LipstickSettings::instance());
     m_qmlEngine->rootContext()->setContextProperty("volumeControl", m_volumeControl);

--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -127,7 +127,8 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     registerDBusObject(systemBus, LIPSTICK_DBUS_SCREENLOCK_PATH, m_screenLock);
     registerDBusObject(systemBus, LIPSTICK_DBUS_SHUTDOWN_PATH, m_shutdownScreen);
     if (!systemBus.registerService(LIPSTICK_DBUS_SERVICE_NAME)) {
-        qWarning("Unable to register D-Bus service %s: %s", LIPSTICK_DBUS_SERVICE_NAME, systemBus.lastError().message().toUtf8().constData());
+        qWarning("Unable to register D-Bus service %s: %s", LIPSTICK_DBUS_SERVICE_NAME,
+                 systemBus.lastError().message().toUtf8().constData());
     }
 
     // Respond to requests for VPN user input
@@ -139,7 +140,8 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
     auto registerVpnAgent = [this]() {
         if (!m_connmanVpn) {
             if (QDBusConnection::systemBus().interface()->isServiceRegistered(LIPSTICK_DBUS_CONNMAN_VPN_SERVICE)) {
-                m_connmanVpn = new ConnmanVpnProxy(LIPSTICK_DBUS_CONNMAN_VPN_SERVICE, "/", QDBusConnection::systemBus());
+                m_connmanVpn = new ConnmanVpnProxy(LIPSTICK_DBUS_CONNMAN_VPN_SERVICE,
+                                                   "/", QDBusConnection::systemBus());
                 m_connmanVpn->RegisterAgent(QDBusObjectPath(LIPSTICK_DBUS_VPNAGENT_PATH));
             }
         }
@@ -151,10 +153,13 @@ HomeApplication::HomeApplication(int &argc, char **argv, const QString &qmlPath)
 
     QDBusServiceWatcher *connmanVpnWatcher
             = new QDBusServiceWatcher(LIPSTICK_DBUS_CONNMAN_VPN_SERVICE, systemBus,
-                                      QDBusServiceWatcher::WatchForRegistration | QDBusServiceWatcher::WatchForUnregistration,
+                                      QDBusServiceWatcher::WatchForRegistration
+                                      | QDBusServiceWatcher::WatchForUnregistration,
                                       this);
-    connect(connmanVpnWatcher, &QDBusServiceWatcher::serviceRegistered, this, [registerVpnAgent](const QString &){ registerVpnAgent(); });
-    connect(connmanVpnWatcher, &QDBusServiceWatcher::serviceUnregistered, this, [unregisterVpnAgent](const QString &){ unregisterVpnAgent(); });
+    connect(connmanVpnWatcher, &QDBusServiceWatcher::serviceRegistered,
+            this, [registerVpnAgent](const QString &){ registerVpnAgent(); });
+    connect(connmanVpnWatcher, &QDBusServiceWatcher::serviceUnregistered,
+            this, [unregisterVpnAgent](const QString &){ unregisterVpnAgent(); });
 
     registerVpnAgent();
 
@@ -220,7 +225,8 @@ void HomeApplication::sendHomeReadySignalIfNotAlreadySent()
 {
     if (!m_homeReadySent) {
         m_homeReadySent = true;
-        disconnect(LipstickCompositor::instance(), SIGNAL(frameSwapped()), this, SLOT(sendHomeReadySignalIfNotAlreadySent()));
+        disconnect(LipstickCompositor::instance(), SIGNAL(frameSwapped()),
+                   this, SLOT(sendHomeReadySignalIfNotAlreadySent()));
 
         emit homeReady();
     }
@@ -241,7 +247,9 @@ void HomeApplication::sendStartupNotifications()
     }
 
     /* Let timed know that the UI is up */
-    systemBus.call(QDBusMessage::createSignal("/com/nokia/startup/signal", "com.nokia.startup.signal", "desktop_visible"), QDBus::NoBlock);
+    systemBus.call(QDBusMessage::createSignal("/com/nokia/startup/signal",
+                                              "com.nokia.startup.signal",
+                                              "desktop_visible"), QDBus::NoBlock);
 }
 
 bool HomeApplication::homeActive() const
@@ -324,7 +332,8 @@ void HomeApplication::setCompositorPath(const QString &path)
     if (compositor) {
         compositor->setParent(this);
         if (LipstickCompositor::instance()) {
-            LipstickCompositor::instance()->setGeometry(QRect(QPoint(0, 0), QGuiApplication::primaryScreen()->size()));
+            LipstickCompositor::instance()->setGeometry(QRect(QPoint(0, 0),
+                                                              QGuiApplication::primaryScreen()->size()));
             connect(m_usbModeSelector, SIGNAL(showUnlockScreen()),
                     LipstickCompositor::instance(), SIGNAL(showUnlockScreen()));
         }
@@ -349,8 +358,10 @@ HomeWindow *HomeApplication::mainWindowInstance()
     m_mainWindowInstance = new HomeWindow();
     m_mainWindowInstance->setGeometry(QRect(QPoint(), QGuiApplication::primaryScreen()->size()));
     m_mainWindowInstance->setWindowTitle("Home");
-    QObject::connect(m_mainWindowInstance->engine(), SIGNAL(quit()), qApp, SLOT(quit()));
-    QObject::connect(m_mainWindowInstance, SIGNAL(visibleChanged(bool)), this, SLOT(connectFrameSwappedSignal(bool)));
+    QObject::connect(m_mainWindowInstance->engine(), SIGNAL(quit()),
+                     qApp, SLOT(quit()));
+    QObject::connect(m_mainWindowInstance, SIGNAL(visibleChanged(bool)),
+                     this, SLOT(connectFrameSwappedSignal(bool)));
 
     // Setting the source, if present
     if (!m_qmlPath.isEmpty())
@@ -367,7 +378,8 @@ QQmlEngine *HomeApplication::engine() const
 void HomeApplication::connectFrameSwappedSignal(bool mainWindowVisible)
 {
     if (!m_homeReadySent && mainWindowVisible) {
-        connect(LipstickCompositor::instance(), SIGNAL(frameSwapped()), this, SLOT(sendHomeReadySignalIfNotAlreadySent()));
+        connect(LipstickCompositor::instance(), SIGNAL(frameSwapped()),
+                this, SLOT(sendHomeReadySignalIfNotAlreadySent()));
     }
 }
 

--- a/src/homewindow.cpp
+++ b/src/homewindow.cpp
@@ -49,7 +49,7 @@ public:
 HomeWindowPrivate::Mode HomeWindowPrivate::mode = HomeWindowPrivate::Unknown;
 
 HomeWindowPrivate::HomeWindowPrivate()
-: isVisible(false), window(0), compositorWindow(0), context(0), root(0)
+    : isVisible(false), window(0), compositorWindow(0), context(0), root(0)
 {
     checkMode();
     if (0 == HomeApplication::instance())
@@ -98,7 +98,7 @@ void HomeWindowPrivate::checkMode()
 }
 
 HomeWindow::HomeWindow()
-: d(new HomeWindowPrivate)
+    : d(new HomeWindowPrivate)
 {
 }
 

--- a/src/lipstickapi.cpp
+++ b/src/lipstickapi.cpp
@@ -19,7 +19,7 @@
 #include "notifications/notificationmanager.h"
 
 LipstickApi::LipstickApi(QObject *parent)
-: QObject(parent)
+    : QObject(parent)
 {
     HomeApplication *homeApp = HomeApplication::instance();
     if (homeApp) {

--- a/src/lipsticksettings.cpp
+++ b/src/lipsticksettings.cpp
@@ -18,6 +18,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <MGConfItem>
+
 #include "screenlock/screenlock.h"
 #include "homeapplication.h"
 #include "lipsticksettings.h"

--- a/src/lipsticksettings.cpp
+++ b/src/lipsticksettings.cpp
@@ -17,6 +17,7 @@
 
 #include <QGuiApplication>
 #include <QScreen>
+#include <QDebug>
 #include <MGConfItem>
 
 #include "screenlock/screenlock.h"
@@ -83,7 +84,7 @@ void LipstickSettings::setInteractionExpected(bool expected)
 
 QSize LipstickSettings::screenSize()
 {
-    return QGuiApplication::primaryScreen()->size();
+    return QGuiApplication::primaryScreen() ? QGuiApplication::primaryScreen()->size() : QSize();
 }
 
 void LipstickSettings::exportScreenProperties()
@@ -91,6 +92,11 @@ void LipstickSettings::exportScreenProperties()
     const int defaultValue = 0;
     MGConfItem widthConf("/lipstick/screen/primary/width");
     QScreen *primaryScreen = QGuiApplication::primaryScreen();
+    if (!primaryScreen) {
+        qWarning() << Q_FUNC_INFO << "No screen found";
+        return;
+    }
+
     QSize primaryScreenSize = primaryScreen->size();
     if (widthConf.value(defaultValue) != primaryScreenSize.width()) {
         widthConf.set(primaryScreenSize.width());

--- a/src/lipsticksettings.h
+++ b/src/lipsticksettings.h
@@ -20,6 +20,7 @@
 #include <QObject>
 #include <QMetaType>
 #include <QSize>
+
 #include "lipstickglobal.h"
 
 class ScreenLock;

--- a/src/touchscreen/touchscreen.cpp
+++ b/src/touchscreen/touchscreen.cpp
@@ -25,7 +25,8 @@
 #include <mce/dbus-names.h>
 #include <mce/mode-names.h>
 
-bool userInteracting(const QEvent *event) {
+static bool userInteracting(const QEvent *event)
+{
     switch(event->type()) {
     case QEvent::TouchBegin:
     case QEvent::TouchUpdate:
@@ -110,7 +111,8 @@ TouchScreen::TouchScreen(QObject *parent)
     , d_ptr(new TouchScreenPrivate(this))
 {
     Q_D(TouchScreen);
-    connect(d->displayState, &DeviceState::DisplayStateMonitor::displayStateChanged, this, [=](DeviceState::DisplayStateMonitor::DisplayState state) {
+    connect(d->displayState, &DeviceState::DisplayStateMonitor::displayStateChanged,
+            this, [=](DeviceState::DisplayStateMonitor::DisplayState state) {
         TouchScreen::DisplayState newState = (TouchScreen::DisplayState)state;
         if (d->currentDisplayState != newState) {
             TouchScreen::DisplayState oldState = d->currentDisplayState;
@@ -216,10 +218,10 @@ bool TouchScreen::eventFilter(QObject *, QEvent *event)
         }
     }
 
-    bool eat = d->eatEvents && (event->type() == QEvent::MouseButtonPress ||
-                                event->type() == QEvent::TouchBegin ||
-                                event->type() == QEvent::TouchUpdate ||
-                                event->type() == QEvent::TouchEnd);
+    bool eat = d->eatEvents && (event->type() == QEvent::MouseButtonPress
+                                || event->type() == QEvent::TouchBegin
+                                || event->type() == QEvent::TouchUpdate
+                                || event->type() == QEvent::TouchEnd);
     if (eat) {
         setEnabled(true);
     }

--- a/src/touchscreen/touchscreen_p.h
+++ b/src/touchscreen/touchscreen_p.h
@@ -21,7 +21,8 @@
 #include "touchscreen.h"
 #include "homeapplication.h"
 
-class TouchScreenPrivate {
+class TouchScreenPrivate
+{
 public:
     explicit TouchScreenPrivate(TouchScreen *q);
 

--- a/src/volume/pulseaudiocontrol.cpp
+++ b/src/volume/pulseaudiocontrol.cpp
@@ -36,11 +36,11 @@ static const char *VOLUME_INTERFACE = "com.Meego.MainVolume2";
 
 #define PA_RECONNECT_TIMEOUT_MS (2000)
 
-PulseAudioControl::PulseAudioControl(QObject *parent) :
-    QObject(parent),
-    m_dbusConnection(NULL),
-    m_reconnectTimeout(PA_RECONNECT_TIMEOUT_MS),
-    m_serviceWatcher(0)
+PulseAudioControl::PulseAudioControl(QObject *parent)
+    : QObject(parent)
+    , m_dbusConnection(NULL)
+    , m_reconnectTimeout(PA_RECONNECT_TIMEOUT_MS)
+    , m_serviceWatcher(0)
 {
 }
 
@@ -74,8 +74,8 @@ void PulseAudioControl::openConnection()
     if (!m_serviceWatcher) {
         m_serviceWatcher = new QDBusServiceWatcher(QStringLiteral("org.pulseaudio.Server"),
                                                    QDBusConnection::sessionBus(),
-                                                   QDBusServiceWatcher::WatchForRegistration |
-                                                     QDBusServiceWatcher::WatchForUnregistration,
+                                                   QDBusServiceWatcher::WatchForRegistration
+                                                   | QDBusServiceWatcher::WatchForUnregistration,
                                                    this);
 
         connect(m_serviceWatcher, SIGNAL(serviceRegistered(const QString&)),
@@ -93,8 +93,10 @@ void PulseAudioControl::openConnection()
     char *pa_bus_address = getenv("PULSE_DBUS_SERVER");
     QByteArray addressArray;
     if (pa_bus_address == NULL) {
-        QDBusMessage message = QDBusMessage::createMethodCall("org.pulseaudio.Server", "/org/pulseaudio/server_lookup1",
-                                                              "org.freedesktop.DBus.Properties", "Get");
+        QDBusMessage message = QDBusMessage::createMethodCall("org.pulseaudio.Server",
+                                                              "/org/pulseaudio/server_lookup1",
+                                                              "org.freedesktop.DBus.Properties",
+                                                              "Get");
         message.setArguments(QVariantList() << "org.PulseAudio.ServerLookup1" << "Address");
         QDBusMessage reply = QDBusConnection::sessionBus().call(message);
         if (reply.type() == QDBusMessage::ReplyMessage && reply.arguments().count() > 0) {
@@ -137,7 +139,8 @@ void PulseAudioControl::update()
     dbus_error_init(&error);
 
     DBusMessage *reply = NULL;
-    DBusMessage *msg = dbus_message_new_method_call(VOLUME_SERVICE, VOLUME_PATH, "org.freedesktop.DBus.Properties", "GetAll");
+    DBusMessage *msg = dbus_message_new_method_call(VOLUME_SERVICE, VOLUME_PATH,
+                                                    "org.freedesktop.DBus.Properties", "GetAll");
     if (msg != NULL) {
         dbus_message_append_args(msg, DBUS_TYPE_STRING, &VOLUME_INTERFACE, DBUS_TYPE_INVALID);
 
@@ -220,8 +223,10 @@ void PulseAudioControl::update()
 
 void PulseAudioControl::addSignalMatch()
 {
-    static const char *signalNames []  = {"com.Meego.MainVolume2.StepsUpdated", "com.Meego.MainVolume2.NotifyHighVolume",
-                                          "com.Meego.MainVolume2.NotifyListeningTime", "com.Meego.MainVolume2.CallStateChanged",
+    static const char *signalNames []  = {"com.Meego.MainVolume2.StepsUpdated",
+                                          "com.Meego.MainVolume2.NotifyHighVolume",
+                                          "com.Meego.MainVolume2.NotifyListeningTime",
+                                          "com.Meego.MainVolume2.CallStateChanged",
                                           "com.Meego.MainVolume2.MediaStateChanged"};
     for (int index = 0; index < 5; ++index) {
         DBusMessage *message = dbus_message_new_method_call(NULL, "/org/pulseaudio/core1", NULL, "ListenForSignal");
@@ -248,7 +253,8 @@ DBusHandlerResult PulseAudioControl::signalHandler(DBusConnection *, DBusMessage
         quint32 currentStep = 0;
         quint32 stepCount = 0;
 
-        if (dbus_message_get_args(message, &error, DBUS_TYPE_UINT32, &stepCount, DBUS_TYPE_UINT32, &currentStep, DBUS_TYPE_INVALID)) {
+        if (dbus_message_get_args(message, &error, DBUS_TYPE_UINT32, &stepCount,
+                                  DBUS_TYPE_UINT32, &currentStep, DBUS_TYPE_INVALID)) {
             static_cast<PulseAudioControl*>(control)->setSteps(currentStep, stepCount);
         }
     } else if (dbus_message_has_member(message, "NotifyHighVolume")) {
@@ -296,10 +302,12 @@ void PulseAudioControl::setVolume(int volume)
         return;
     }
 
-    DBusMessage *message = dbus_message_new_method_call(VOLUME_SERVICE, VOLUME_PATH, "org.freedesktop.DBus.Properties", "Set");
+    DBusMessage *message = dbus_message_new_method_call(VOLUME_SERVICE, VOLUME_PATH,
+                                                        "org.freedesktop.DBus.Properties", "Set");
     if (message != NULL) {
         static const char *method = "CurrentStep";
-        if (dbus_message_append_args(message, DBUS_TYPE_STRING, &VOLUME_INTERFACE, DBUS_TYPE_STRING, &method, DBUS_TYPE_INVALID)) {
+        if (dbus_message_append_args(message, DBUS_TYPE_STRING,
+                                     &VOLUME_INTERFACE, DBUS_TYPE_STRING, &method, DBUS_TYPE_INVALID)) {
             DBusMessageIter append;
             DBusMessageIter sub;
 


### PR DESCRIPTION
Main commit:

    [lipstick] Protect a bit against no primary screen present. JB#62930
    
    Without a screen things won't likely proceed well now, but nicer to
    abort with an error message rather than just segfaulting with null
    reference.

One other commit for some coding style adjustments.