### PR TITLE
Back key control

### DIFF
--- a/src/compositor/alienmanager/alienmanager.cpp
+++ b/src/compositor/alienmanager/alienmanager.cpp
@@ -18,9 +18,8 @@
 #include "aliensurface.h"
 
 AlienManagerGlobal::AlienManagerGlobal(QObject *parent)
-                  : QObject(parent)
+    : QObject(parent)
 {
-
 }
 
 const wl_interface *AlienManagerGlobal::interface() const
@@ -36,8 +35,8 @@ void AlienManagerGlobal::bind(wl_client *client, uint32_t version, uint32_t id)
 
 
 AlienManager::AlienManager(wl_client *client, uint32_t version, uint32_t id, QObject *parent)
-            : QObject(parent)
-            , QtWaylandServer::alien_manager(client, id, version)
+    : QObject(parent)
+    , QtWaylandServer::alien_manager(client, id, version)
 {
 }
 
@@ -78,10 +77,10 @@ void AlienManager::alien_manager_pong(Resource *resource, uint32_t serial)
 
 
 AlienClient::AlienClient(AlienManager *mgr, wl_client *client, uint32_t version, uint32_t id, const QString &package)
-           : QObject(mgr)
-           , QtWaylandServer::alien_client(client, id, version)
-           , m_package(package)
-           , m_manager(mgr)
+    : QObject(mgr)
+    , QtWaylandServer::alien_client(client, id, version)
+    , m_package(package)
+    , m_manager(mgr)
 {
 }
 

--- a/src/compositor/alienmanager/aliensurface.cpp
+++ b/src/compositor/alienmanager/aliensurface.cpp
@@ -15,10 +15,7 @@
 #include <QtCompositorVersion>
 
 #include <QtCompositor/QWaylandSurface>
-
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 #include <QtCompositor/QWaylandClient>
-#endif
 
 #include "lipstickcompositor.h"
 #include "lipstickcompositorwindow.h"
@@ -30,11 +27,7 @@ AlienSurface::AlienSurface(AlienClient *client, QWaylandSurface *surface, uint32
                            const QString &package)
     : QObject(client)
     , QWaylandSurfaceInterface(surface)
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     , QtWaylandServer::alien_surface(surface->client()->client(), id, version)
-#else
-    , QtWaylandServer::alien_surface(reinterpret_cast<wl_client *>(surface->client()), id, version)
-#endif
     , m_client(client)
     , m_hidden(false)
     , m_coverized(false)

--- a/src/compositor/alienmanager/aliensurface.cpp
+++ b/src/compositor/alienmanager/aliensurface.cpp
@@ -26,20 +26,21 @@
 #include "alienmanager.h"
 #include "lipsticksurfaceinterface.h"
 
-AlienSurface::AlienSurface(AlienClient *client, QWaylandSurface *surface, uint32_t version, uint32_t id, const QString &package)
-            : QObject(client)
-            , QWaylandSurfaceInterface(surface)
+AlienSurface::AlienSurface(AlienClient *client, QWaylandSurface *surface, uint32_t version, uint32_t id,
+                           const QString &package)
+    : QObject(client)
+    , QWaylandSurfaceInterface(surface)
 #if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-            , QtWaylandServer::alien_surface(surface->client()->client(), id, version)
+    , QtWaylandServer::alien_surface(surface->client()->client(), id, version)
 #else
-            , QtWaylandServer::alien_surface(reinterpret_cast<wl_client *>(surface->client()), id, version)
+    , QtWaylandServer::alien_surface(reinterpret_cast<wl_client *>(surface->client()), id, version)
 #endif
-            , m_client(client)
-            , m_hidden(false)
-            , m_coverized(false)
-            , m_lastSize(0, 0)
-            , m_serial(0)
-            , m_lastSerial(0)
+    , m_client(client)
+    , m_hidden(false)
+    , m_coverized(false)
+    , m_lastSize(0, 0)
+    , m_serial(0)
+    , m_lastSerial(0)
 {
     LipstickCompositor *compositor = LipstickCompositor::instance();
     sendConfigure(compositor->width(), compositor->height());

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -60,14 +60,9 @@ bool debuggingCompositorHandover()
 LipstickCompositor *LipstickCompositor::m_instance = 0;
 
 LipstickCompositor::LipstickCompositor()    
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     : QWaylandQuickCompositor(nullptr,
                               (QWaylandCompositor::ExtensionFlags)QWaylandCompositor::DefaultExtensions & ~QWaylandCompositor::QtKeyExtension)
     , m_output(this, this, QString(), QString())
-#else
-    : QWaylandQuickCompositor(this, 0,
-                              (QWaylandCompositor::ExtensionFlags)QWaylandCompositor::DefaultExtensions & ~QWaylandCompositor::QtKeyExtension)
-#endif
     , m_totalWindowCount(0)
     , m_nextWindowId(1)
     , m_homeActive(true)
@@ -201,14 +196,10 @@ void LipstickCompositor::onVisibleChanged(bool visible)
 
 void LipstickCompositor::componentComplete()
 {
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QScreen * const screen = QGuiApplication::primaryScreen();
 
     m_output.setGeometry(QRect(QPoint(0, 0), screen->size()));
     m_output.setPhysicalSize(screen->physicalSize().toSize());
-#else
-    QWaylandCompositor::setOutputGeometry(QRect(0, 0, width(), height()));
-#endif
 }
 
 void LipstickCompositor::surfaceCreated(QWaylandSurface *surface)

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -74,6 +74,7 @@ LipstickCompositor::LipstickCompositor()
     , m_retainedSelection(0)
     , m_updatesEnabled(true)
     , m_completed(false)
+    , m_synthesizeBackEvent(true)
     , m_onUpdatesDisabledUnfocusedWindowId(0)
     , m_keymap(0)
     , m_fakeRepaintTimerId(0)
@@ -301,6 +302,19 @@ QWaylandSurface *LipstickCompositor::surfaceForId(int id) const
 bool LipstickCompositor::completed()
 {
     return m_completed;
+}
+
+bool LipstickCompositor::synthesizeBackEvent() const
+{
+    return m_synthesizeBackEvent;
+}
+
+void LipstickCompositor::setSynthesizeBackEvent(bool enable)
+{
+    if (enable != m_synthesizeBackEvent) {
+        m_synthesizeBackEvent = enable;
+        emit synthesizeBackEventChanged();
+    }
 }
 
 int LipstickCompositor::windowIdForLink(int siblingId, uint link) const
@@ -905,7 +919,7 @@ bool LipstickCompositor::event(QEvent *event)
     if (event->type() == QEvent::MouseButtonPress || event->type() == QEvent::MouseButtonRelease) {
         QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
 
-        if (mouseEvent->button() == Qt::RightButton) {
+        if (m_synthesizeBackEvent && mouseEvent->button() == Qt::RightButton) {
             // see xkeyboard-config/keycodes/evdev: Map to <I166> = 166; #define KEY_BACK
             int scanCode = 166;
             if (mouseEvent->type() == QEvent::MouseButtonPress) {

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -61,10 +61,12 @@ LipstickCompositor *LipstickCompositor::m_instance = 0;
 
 LipstickCompositor::LipstickCompositor()    
 #if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    : QWaylandQuickCompositor(nullptr, (QWaylandCompositor::ExtensionFlags)QWaylandCompositor::DefaultExtensions & ~QWaylandCompositor::QtKeyExtension)
+    : QWaylandQuickCompositor(nullptr,
+                              (QWaylandCompositor::ExtensionFlags)QWaylandCompositor::DefaultExtensions & ~QWaylandCompositor::QtKeyExtension)
     , m_output(this, this, QString(), QString())
 #else
-    : QWaylandQuickCompositor(this, 0, (QWaylandCompositor::ExtensionFlags)QWaylandCompositor::DefaultExtensions & ~QWaylandCompositor::QtKeyExtension)
+    : QWaylandQuickCompositor(this, 0,
+                              (QWaylandCompositor::ExtensionFlags)QWaylandCompositor::DefaultExtensions & ~QWaylandCompositor::QtKeyExtension)
 #endif
     , m_totalWindowCount(0)
     , m_nextWindowId(1)
@@ -382,7 +384,8 @@ QWaylandSurfaceView *LipstickCompositor::createView(QWaylandSurface *surface)
     QString category = properties.value("CATEGORY").toString();
 
     int id = m_nextWindowId++;
-    LipstickCompositorWindow *item = new LipstickCompositorWindow(id, category, static_cast<QWaylandQuickSurface *>(surface));
+    LipstickCompositorWindow *item = new LipstickCompositorWindow(id, category,
+                                                                  static_cast<QWaylandQuickSurface *>(surface));
     item->setParent(this);
     QObject::connect(item, SIGNAL(destroyed(QObject*)), this, SLOT(windowDestroyed()));
     m_windows.insert(item->windowId(), item);

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -85,6 +85,7 @@ class LIPSTICK_EXPORT LipstickCompositor
     Q_PROPERTY(QVariant orientationLock READ orientationLock NOTIFY orientationLockChanged)
     Q_PROPERTY(bool displayDimmed READ displayDimmed NOTIFY displayDimmedChanged)
     Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
+    Q_PROPERTY(bool synthesizeBackEvent READ synthesizeBackEvent WRITE setSynthesizeBackEvent NOTIFY synthesizeBackEventChanged)
 
 public:
     LipstickCompositor();
@@ -168,6 +169,9 @@ public:
 
     bool completed();
 
+    bool synthesizeBackEvent() const;
+    void setSynthesizeBackEvent(bool enable);
+
     void setUpdatesEnabledNow(bool enabled);
     void setUpdatesEnabled(bool enabled);
     QWaylandSurfaceView *createView(QWaylandSurface *surf) Q_DECL_OVERRIDE;
@@ -207,6 +211,7 @@ signals:
     void displayAboutToBeOff();
 
     void completedChanged();
+    void synthesizeBackEventChanged();
 
     void showUnlockScreen();
 
@@ -279,6 +284,7 @@ private:
     MGConfItem *m_orientationLock;
     bool m_updatesEnabled;
     bool m_completed;
+    bool m_synthesizeBackEvent;
     int m_onUpdatesDisabledUnfocusedWindowId;
     LipstickRecorderManager *m_recorder;
     LipstickKeymap *m_keymap;

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -21,9 +21,7 @@
 #include "homeapplication.h"
 #include <QQmlParserStatus>
 #include <QtCompositorVersion>
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 #include <QWaylandQuickOutput>
-#endif
 #include <QWaylandQuickCompositor>
 #include <QWaylandSurfaceItem>
 #include <QPointer>
@@ -61,9 +59,7 @@ struct QueuedSetUpdatesEnabledCall
 };
 
 
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 typedef QWaylandClient WaylandClient;
-#endif
 
 class LIPSTICK_EXPORT LipstickCompositor
     : public QQuickWindow
@@ -260,9 +256,7 @@ private:
     static LipstickCompositor *m_instance;
 
 #ifndef LIPSTICK_UNIT_TEST_STUB
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     QWaylandQuickOutput m_output;
-#endif
 #endif
 
     int m_totalWindowCount;

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -154,7 +154,10 @@ public:
     Q_INVOKABLE void clearKeyboardFocus();
     Q_INVOKABLE void setDisplayOff();
     Q_INVOKABLE QVariant settingsValue(const QString &key, const QVariant &defaultValue = QVariant()) const
-        { return (key == "orientationLock") ? m_orientationLock->value(defaultValue) : MGConfItem("/lipstick/" + key).value(defaultValue); }
+    {
+        return (key == "orientationLock") ? m_orientationLock->value(defaultValue)
+                                          : MGConfItem("/lipstick/" + key).value(defaultValue);
+    }
     Q_INVOKABLE void openUrl(const QString &url)
     {
         openUrl(QUrl(url));
@@ -162,7 +165,8 @@ public:
     Q_INVOKABLE bool openUrl(const QUrl &);
 
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &);
-    LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &, QQuickItem *rootItem);
+    LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &,
+                                                QQuickItem *rootItem);
 
     QWaylandSurface *surfaceForId(int) const;
 

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -18,9 +18,7 @@
 #include <QCoreApplication>
 #include <QWaylandCompositor>
 #include <QWaylandInputDevice>
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 #include <QWaylandClient>
-#endif
 #include <QTimer>
 #include <sys/types.h>
 #include <signal.h>
@@ -56,11 +54,7 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
     });
 
     if (surface) {
-#if QTCOMPOSITOR_VERSION >= QT_VERSION_CHECK(5, 6, 0)
         m_processId = surface->client()->processId();
-#else
-        m_processId = surface->processId();
-#endif
 
         m_isAlien = surface->property("alienSurface").toBool();
 

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -30,10 +30,18 @@
 
 LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &category,
                                                    QWaylandQuickSurface *surface, QQuickItem *parent)
-: QWaylandSurfaceItem(surface, parent), m_processId(0), m_windowId(windowId), m_isAlien(false), m_category(category),
-  m_delayRemove(false), m_windowClosed(false), m_removePosted(false), m_mouseRegionValid(false),
-  m_interceptingTouch(false), m_mapped(false),
-  m_focusOnTouch(false)
+    : QWaylandSurfaceItem(surface, parent)
+    , m_processId(0)
+    , m_windowId(windowId)
+    , m_isAlien(false)
+    , m_category(category)
+    , m_delayRemove(false)
+    , m_windowClosed(false)
+    , m_removePosted(false)
+    , m_mouseRegionValid(false)
+    , m_interceptingTouch(false)
+    , m_mapped(false)
+    , m_focusOnTouch(false)
 {
     setFlags(QQuickItem::ItemIsFocusScope | flags());
     refreshMouseRegion();
@@ -274,10 +282,14 @@ bool LipstickCompositorWindow::eventFilter(QObject *obj, QEvent *event)
         }
         return false;
     }
+
     if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
         QKeyEvent *ke = static_cast<QKeyEvent *>(event);
         QWaylandSurface *m_surface = surface();
-        if (m_surface && (m_grabbedKeys.contains(ke->key()) || m_pressedGrabbedKeys.keys.contains(ke->key())) && !ke->isAutoRepeat()) {
+
+        if (m_surface
+                && (m_grabbedKeys.contains(ke->key()) || m_pressedGrabbedKeys.keys.contains(ke->key()))
+                && !ke->isAutoRepeat()) {
             QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
             if (event->type() == QEvent::KeyPress) {
                 if (m_pressedGrabbedKeys.keys.isEmpty()) {
@@ -328,9 +340,11 @@ bool LipstickCompositorWindow::event(QEvent *e)
 void LipstickCompositorWindow::mousePressEvent(QMouseEvent *event)
 {
     QWaylandSurface *m_surface = surface();
-    if (m_surface && (!m_mouseRegionValid || m_mouseRegion.contains(event->pos())) &&
-        m_surface->inputRegionContains(event->pos()) && event->source() != Qt::MouseEventSynthesizedByQt) {
+    if (m_surface
+            && (!m_mouseRegionValid || m_mouseRegion.contains(event->pos()))
+            && m_surface->inputRegionContains(event->pos()) && event->source() != Qt::MouseEventSynthesizedByQt) {
         QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
+
         if (inputDevice->mouseFocus() != this) {
             inputDevice->setMouseFocus(this, event->pos(), event->globalPos());
             if (m_focusOnTouch && inputDevice->keyboardFocus() != m_surface) {

--- a/src/compositor/lipstickrecorder.cpp
+++ b/src/compositor/lipstickrecorder.cpp
@@ -51,7 +51,7 @@ public:
 };
 
 LipstickRecorderManager::LipstickRecorderManager()
-                       : QWaylandGlobalInterface()
+    : QWaylandGlobalInterface()
 {
 }
 
@@ -111,12 +111,14 @@ void LipstickRecorderManager::bind(wl_client *client, quint32 version, quint32 i
     wl_client_get_credentials(client, Q_NULLPTR, Q_NULLPTR, &gid);
     group *g = getgrgid(gid);
     if (strcmp(g->gr_name, "privileged") != 0) {
-        wl_resource_post_error(res->handle, WL_DISPLAY_ERROR_INVALID_OBJECT, "Permission to bind lipstick_recorder_manager denied");
+        wl_resource_post_error(res->handle, WL_DISPLAY_ERROR_INVALID_OBJECT,
+                               "Permission to bind lipstick_recorder_manager denied");
         wl_resource_destroy(res->handle);
     }
 }
 
-void LipstickRecorderManager::lipstick_recorder_manager_create_recorder(Resource *resource, uint32_t id, ::wl_resource *output)
+void LipstickRecorderManager::lipstick_recorder_manager_create_recorder(Resource *resource, uint32_t id,
+                                                                        ::wl_resource *output)
 {
     // TODO: we should find out the window associated with this output, but there isn't
     // a way to do that in qtcompositor yet. Just ignore it for now and use the one window we have.
@@ -126,12 +128,13 @@ void LipstickRecorderManager::lipstick_recorder_manager_create_recorder(Resource
 }
 
 
-LipstickRecorder::LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id, QQuickWindow *window)
-                : QtWaylandServer::lipstick_recorder(client, id, 1)
-                , m_manager(manager)
-                , m_bufferResource(Q_NULLPTR)
-                , m_client(client)
-                , m_window(window)
+LipstickRecorder::LipstickRecorder(LipstickRecorderManager *manager, wl_client *client, quint32 id,
+                                   QQuickWindow *window)
+    : QtWaylandServer::lipstick_recorder(client, id, 1)
+    , m_manager(manager)
+    , m_bufferResource(Q_NULLPTR)
+    , m_client(client)
+    , m_window(window)
 {
     send_setup(window->width(), window->height(), window->width() * 4, WL_SHM_FORMAT_RGBA8888);
 }

--- a/src/compositor/lipsticksurfaceinterface.cpp
+++ b/src/compositor/lipsticksurfaceinterface.cpp
@@ -15,7 +15,7 @@
 #include "lipsticksurfaceinterface.h"
 
 LipstickOomScoreOp::LipstickOomScoreOp(int score)
-                  : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
-                  , m_score(score)
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+    , m_score(score)
 {
 }

--- a/src/compositor/windowpixmapitem.cpp
+++ b/src/compositor/windowpixmapitem.cpp
@@ -658,9 +658,10 @@ public:
 
 
 WindowPixmapItem::WindowPixmapItem()
-: m_item(0), m_id(0), m_opaque(false), m_radius(0), m_xOffset(0), m_yOffset(0)
-, m_xScale(1), m_yScale(1), m_unmapLock(0), m_hasBuffer(false), m_hasPixmap(false), m_surfaceDestroyed(false), m_haveSnapshot(false)
-, m_textureProvider(0)
+    : m_item(0), m_id(0), m_opaque(false), m_radius(0), m_xOffset(0), m_yOffset(0)
+    , m_xScale(1), m_yScale(1), m_unmapLock(0), m_hasBuffer(false), m_hasPixmap(false)
+    , m_surfaceDestroyed(false), m_haveSnapshot(false)
+    , m_textureProvider(0)
 {
     setFlag(ItemHasContents);
 }

--- a/src/compositor/windowproperty.cpp
+++ b/src/compositor/windowproperty.cpp
@@ -17,7 +17,7 @@
 #include "lipstickcompositor.h"
 
 WindowProperty::WindowProperty()
-: m_windowId(0), m_waitingRefProperty(false)
+    : m_windowId(0), m_waitingRefProperty(false)
 {
     LipstickCompositor *c = LipstickCompositor::instance();
     if (!c)

--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -237,22 +237,15 @@ void HomeApplication::sendHomeReadySignalIfNotAlreadySent()
 
 void HomeApplication::sendStartupNotifications()
 {
-    static QDBusConnection systemBus = QDBusConnection::systemBus();
-    QDBusMessage homeReadySignal =
-        QDBusMessage::createSignal("/com/nokia/duihome",
-                                   "com.nokia.duihome.readyNotifier",
-                                   "ready");
-    systemBus.send(homeReadySignal);
-
     /* Let systemd know that we are initialized */
     if (arguments().indexOf("--systemd") >= 0) {
         sd_notify(0, "READY=1");
     }
 
     /* Let timed know that the UI is up */
-    systemBus.call(QDBusMessage::createSignal("/com/nokia/startup/signal",
-                                              "com.nokia.startup.signal",
-                                              "desktop_visible"), QDBus::NoBlock);
+    QDBusConnection::systemBus().call(QDBusMessage::createSignal("/com/nokia/startup/signal",
+                                                                 "com.nokia.startup.signal",
+                                                                 "desktop_visible"), QDBus::NoBlock);
 }
 
 bool HomeApplication::homeActive() const

--- a/src/homewindow.cpp
+++ b/src/homewindow.cpp
@@ -29,7 +29,12 @@ public:
     HomeWindowPrivate();
     ~HomeWindowPrivate();
 
-    enum Mode { Unknown, Compositor, Window };
+    enum Mode {
+        Unknown,
+        Compositor,
+        Window
+    };
+
     static Mode mode;
     static bool isWindow();
     static bool isCompositor();

--- a/src/notifications/categorydefinitionstore.cpp
+++ b/src/notifications/categorydefinitionstore.cpp
@@ -41,8 +41,10 @@ CategoryDefinitionStore::CategoryDefinitionStore(const QString &categoryDefiniti
 
     // Watch for changes in category definition files
     m_categoryDefinitionPathWatcher.addPath(this->m_categoryDefinitionsPath);
-    connect(&m_categoryDefinitionPathWatcher, SIGNAL(directoryChanged(QString)), this, SLOT(updateCategoryDefinitionFileList()));
-    connect(&m_categoryDefinitionPathWatcher, SIGNAL(fileChanged(QString)), this, SLOT(updateCategoryDefinitionFile(QString)));
+    connect(&m_categoryDefinitionPathWatcher, SIGNAL(directoryChanged(QString)),
+            this, SLOT(updateCategoryDefinitionFileList()));
+    connect(&m_categoryDefinitionPathWatcher, SIGNAL(fileChanged(QString)),
+            this, SLOT(updateCategoryDefinitionFile(QString)));
     updateCategoryDefinitionFileList();
 }
 

--- a/src/utilities/closeeventeater.cpp
+++ b/src/utilities/closeeventeater.cpp
@@ -16,7 +16,8 @@
 #include "closeeventeater.h"
 #include <QEvent>
 
-CloseEventEater::CloseEventEater(QObject *parent) : QObject(parent)
+CloseEventEater::CloseEventEater(QObject *parent)
+    : QObject(parent)
 {
 }
 

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -73,6 +73,8 @@ public:
     virtual void readContent();
     virtual void initialize();
     virtual bool completed();
+    virtual bool synthesizeBackEvent() const;
+    virtual void setSynthesizeBackEvent(bool enable);
     virtual void timerEvent(QTimerEvent *e);
     virtual bool event(QEvent *e);
     virtual void sendKeyEvent(QEvent::Type type, Qt::Key key, quint32 nativeScanCode);
@@ -310,6 +312,18 @@ bool LipstickCompositorStub::completed()
 {
     stubMethodEntered("completed");
     return true;
+}
+
+bool LipstickCompositorStub::synthesizeBackEvent() const
+{
+    stubMethodEntered("synthesizeBackEvent");
+    return true;
+}
+
+void LipstickCompositorStub::setSynthesizeBackEvent(bool enable)
+{
+    Q_UNUSED(enable);
+    stubMethodEntered("setSynthesizeBackEvent");
 }
 
 void LipstickCompositorStub::timerEvent(QTimerEvent *e)
@@ -635,6 +649,16 @@ void LipstickCompositor::initialize()
 bool LipstickCompositor::completed()
 {
     return gLipstickCompositorStub->completed();
+}
+
+bool LipstickCompositor::synthesizeBackEvent() const
+{
+    return gLipstickCompositorStub->synthesizeBackEvent();
+}
+
+void LipstickCompositor::setSynthesizeBackEvent(bool enable)
+{
+    gLipstickCompositorStub->setSynthesizeBackEvent(enable);
 }
 
 void LipstickCompositor::timerEvent(QTimerEvent *e)


### PR DESCRIPTION
Main commit:

    [lipstick] Allow the homescreen to control when key back events are synhtesized. JB#62979
    
    Still being a bit rough when compositor is filtering all events instead
    of what gets the event in scenegraph stack, but at least this allows
    some control when there's homescreen UI on top of the app.
