### PR TITLE
[lipstick] Activate LipstickCompositorWindow mouse focus on wheel event. JB#62969

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -378,6 +378,12 @@ void LipstickCompositorWindow::wheelEvent(QWheelEvent *event)
     QWaylandSurface *m_surface = surface();
     if (m_surface) {
         QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
+        if (inputDevice->mouseFocus() != this) {
+            inputDevice->setMouseFocus(this, event->pos(), event->globalPos());
+            if (m_focusOnTouch && inputDevice->keyboardFocus() != m_surface) {
+                takeFocus();
+            }
+        }
         inputDevice->sendMouseWheelEvent(event->orientation(), event->delta());
     } else {
         event->ignore();


### PR DESCRIPTION
The application wasn't getting wheel events until a mouse press moved the mouse focus there. Applied now a similar handling on wheel event.

Not fully sure about all the details. In practice only the setMouseFocus() happens when launching an app and doing some wheel events, and that's also enough.