### PR TITLE
[lipstick] Ensure the qml plugin loads translations.

### DIFF
--- a/plugin/lipstickplugin.cpp
+++ b/plugin/lipstickplugin.cpp
@@ -17,6 +17,7 @@
 #include "lipstickplugin.h"
 
 #include <QtQml>
+
 #include <components/launcheritem.h>
 #include <components/launcherwatchermodel.h>
 #include <notifications/notificationpreviewpresenter.h>
@@ -33,15 +34,31 @@
 #include <compositor/windowpixmapitem.h>
 #include <compositor/windowproperty.h>
 #include <lipstickapi.h>
+#include <homeapplication.h>
 
 static QObject *lipstickApi_callback(QQmlEngine *e, QJSEngine *)
 {
     return new LipstickApi(e);
 }
 
-LipstickPlugin::LipstickPlugin(QObject *parent) :
-    QQmlExtensionPlugin(parent)
+LipstickPlugin::LipstickPlugin(QObject *parent)
+    : QQmlExtensionPlugin(parent)
 {
+}
+
+void LipstickPlugin::initializeEngine(QQmlEngine *engine, const char *uri)
+{
+    Q_UNUSED(uri)
+    Q_UNUSED(engine)
+    Q_ASSERT(QLatin1String(uri) == QLatin1String("org.nemomobile.lipstick"));
+
+    if (!HomeApplication::instance()) {
+        // within homescreen we have these already loaded but otherwise plugin needs to handle
+        AppTranslator *engineeringEnglish = new AppTranslator(engine);
+        AppTranslator *translator = new AppTranslator(engine);
+        engineeringEnglish->load("lipstick_eng_en", "/usr/share/translations");
+        translator->load(QLocale(), "lipstick", "-", "/usr/share/translations");
+    }
 }
 
 void LipstickPlugin::registerTypes(const char *uri)
@@ -82,5 +99,5 @@ void LipstickPlugin::registerTypes(const char *uri)
     qmlRegisterType<LipstickCompositorWindow>();
     qmlRegisterType<QObjectListModel>();
 
-    qmlRegisterRevision<QQuickWindow,1>("org.nemomobile.lipstick", 0, 1);
+    qmlRegisterRevision<QQuickWindow, 1>("org.nemomobile.lipstick", 0, 1);
 }

--- a/plugin/lipstickplugin.h
+++ b/plugin/lipstickplugin.h
@@ -19,6 +19,9 @@
 
 #include <QQmlExtensionPlugin>
 #include <QQmlParserStatus>
+#include <QTranslator>
+#include <QCoreApplication>
+
 #include <components/launchermodel.h>
 #include <components/launcherfoldermodel.h>
 
@@ -30,6 +33,7 @@ class Q_DECL_EXPORT LipstickPlugin : public QQmlExtensionPlugin
 public:
     explicit LipstickPlugin(QObject *parent = 0);
 
+    void initializeEngine(QQmlEngine *engine, const char *uri);
     void registerTypes(const char *uri);
 };
 
@@ -61,5 +65,20 @@ public:
     void componentComplete() { initialize(); }
 };
 
+class AppTranslator: public QTranslator
+{
+    Q_OBJECT
+public:
+    AppTranslator(QObject *parent)
+        : QTranslator(parent)
+    {
+        qApp->installTranslator(this);
+    }
+
+    virtual ~AppTranslator()
+    {
+        qApp->removeTranslator(this);
+    }
+};
 
 #endif // LIPSTICKPLUGIN_H


### PR DESCRIPTION
The API can be used to fetch content which needs translations. Hence needs to load the translations too.