### PR TITLE
Honor mouse region for wheel events

### DIFF
--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -420,8 +420,8 @@ void LipstickCompositorWindow::handleTouchEvent(QTouchEvent *event)
 
     if (event->touchPointStates() & Qt::TouchPointPressed) {
         foreach (const QTouchEvent::TouchPoint &p, points) {
-            if ((m_mouseRegionValid && !m_mouseRegion.contains(p.pos().toPoint())) ||
-                !m_surface->inputRegionContains(p.pos().toPoint())) {
+            if ((m_mouseRegionValid && !m_mouseRegion.contains(p.pos().toPoint()))
+                    || !m_surface->inputRegionContains(p.pos().toPoint())) {
                 event->ignore();
                 return;
             }
@@ -450,8 +450,8 @@ void LipstickCompositorWindow::handleTouchCancel()
     if (!m_surface)
         return;
     QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
-    if (inputDevice->mouseFocus() == this &&
-            (!isVisible() || !isEnabled() || !touchEventsEnabled())) {
+    if (inputDevice->mouseFocus() == this
+            && (!isVisible() || !isEnabled() || !touchEventsEnabled())) {
         inputDevice->sendTouchCancelEvent();
         inputDevice->setMouseFocus(0, QPointF());
     }

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -376,7 +376,9 @@ void LipstickCompositorWindow::mouseReleaseEvent(QMouseEvent *event)
 void LipstickCompositorWindow::wheelEvent(QWheelEvent *event)
 {
     QWaylandSurface *m_surface = surface();
-    if (m_surface) {
+    if (m_surface
+            && (!m_mouseRegionValid || m_mouseRegion.contains(event->pos()))
+            && m_surface->inputRegionContains(event->pos()) && event->source() != Qt::MouseEventSynthesizedByQt) {
         QWaylandInputDevice *inputDevice = m_surface->compositor()->defaultInputDevice();
         if (inputDevice->mouseFocus() != this) {
             inputDevice->setMouseFocus(this, event->pos(), event->globalPos());

--- a/src/compositor/lipstickkeymap.cpp
+++ b/src/compositor/lipstickkeymap.cpp
@@ -72,10 +72,10 @@ void LipstickKeymap::setOptions(const QString &options)
 
 bool operator!=(const LipstickKeymap &a, const LipstickKeymap &b)
 {
-    return a.rules() != b.rules() ||
-        a.model() != b.model() ||
-        a.layout() != b.layout() ||
-        a.variant() != b.variant() ||
-        a.options() != b.options();
+    return a.rules() != b.rules()
+            || a.model() != b.model()
+            || a.layout() != b.layout()
+            || a.variant() != b.variant()
+            || a.options() != b.options();
 }
 

--- a/src/homeapplication.cpp
+++ b/src/homeapplication.cpp
@@ -274,10 +274,11 @@ void HomeApplication::setDisplayOff()
 bool HomeApplication::event(QEvent *e)
 {
     bool rv = QGuiApplication::event(e);
-    if (LipstickCompositor::instance() == 0 &&
-        (e->type() == QEvent::ApplicationActivate ||
-         e->type() == QEvent::ApplicationDeactivate))
+    if (LipstickCompositor::instance() == 0
+            && (e->type() == QEvent::ApplicationActivate
+                || e->type() == QEvent::ApplicationDeactivate)) {
         emit homeActiveChanged();
+    }
     return rv;
 }
 

--- a/src/volume/volumecontrol.cpp
+++ b/src/volume/volumecontrol.cpp
@@ -62,7 +62,8 @@ VolumeControl::VolumeControl(bool hwKeysCapability, QObject *parent) :
         m_hwKeysEnabled = true;
         m_hwKeyResource->setAlwaysReply();
         m_hwKeyResource->addResourceObject(new ResourcePolicy::ScaleButtonResource);
-        connect(m_hwKeyResource, SIGNAL(resourcesGranted(QList<ResourcePolicy::ResourceType>)), this, SLOT(hwKeyResourceAcquired()));
+        connect(m_hwKeyResource, SIGNAL(resourcesGranted(QList<ResourcePolicy::ResourceType>)),
+                this, SLOT(hwKeyResourceAcquired()));
         connect(m_hwKeyResource, SIGNAL(lostResources()), this, SLOT(hwKeyResourceLost()));
         m_hwKeyResource->acquire();
 
@@ -97,7 +98,6 @@ VolumeControl::VolumeControl(bool hwKeysCapability, QObject *parent) :
     connect(m_pulseAudioControl, SIGNAL(callActiveChanged(bool)), SLOT(handleCallActive(bool)));
     connect(m_pulseAudioControl, SIGNAL(mediaStateChanged(QString)), SLOT(handleMediaStateChanged(QString)));
     m_pulseAudioControl->update();
-
 }
 
 VolumeControl::~VolumeControl()
@@ -287,6 +287,7 @@ void VolumeControl::hwKeysEnabled()
         evaluateKeyState();
     }
 }
+
 void VolumeControl::hwKeysDisabled()
 {
     if (m_hwKeysEnabled) {
@@ -385,8 +386,8 @@ bool VolumeControl::eventFilter(QObject *, QEvent *event)
 {
     bool handled = false;
 
-    if (m_hwKeysActive && (event->type() == QEvent::KeyPress ||
-                           event->type() == QEvent::KeyRelease)) {
+    if (m_hwKeysActive && (event->type() == QEvent::KeyPress
+                           || event->type() == QEvent::KeyRelease)) {
         bool pressed = (event->type() == QEvent::KeyPress);
 
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);

--- a/src/vpnagent.cpp
+++ b/src/vpnagent.cpp
@@ -91,10 +91,10 @@ void VpnAgent::respond(const QString &path, const QVariantMap &details)
                 && (fieldType == QStringLiteral("boolean"))) {
             keepCredentials = fieldValue.toBool();
         } else {
-            if (fieldRequirement == QStringLiteral("mandatory") ||
-                (fieldRequirement != QStringLiteral("informational")
-                 && fieldRequirement != QStringLiteral("control")
-                 && fieldValue.isValid())) {
+            if (fieldRequirement == QStringLiteral("mandatory")
+                    || (fieldRequirement != QStringLiteral("informational")
+                        && fieldRequirement != QStringLiteral("control")
+                        && fieldValue.isValid())) {
                 response.insert(it.key(), fieldValue);
             }
         }


### PR DESCRIPTION
Similar to mouse presses etc, check that the event happens on top of region the window has declared if non-empty.