### PR TITLE
Doc->src dependency

### DIFF
--- a/doc/doc.pro
+++ b/doc/doc.pro
@@ -30,4 +30,4 @@ notification_htmldocs.CONFIG += no_check_exist
 
 INSTALLS += htmldocs notification_htmldocs
 
-OTHER_FILES = src/*.dox
+OTHER_FILES = src/*.dox doxygen.cfg

--- a/lipstick.pro
+++ b/lipstick.pro
@@ -4,6 +4,7 @@ SUBDIRS += src plugin tools tests doc
 plugin.depends = src
 tools.depends = src
 tests.depends = src
+doc.depends = src
 
 QMAKE_CLEAN += \
     build-stamp \

--- a/src/src.pro
+++ b/src/src.pro
@@ -124,7 +124,7 @@ SOURCES += \
     devicestate/devicestate.cpp \
     logging.cpp \
 
-CONFIG += link_pkgconfig mobility qt warn_on depend_includepath qmake_cache target_qt
+CONFIG += link_pkgconfig qt warn_on depend_includepath qmake_cache target_qt
 CONFIG -= link_prl
 PKGCONFIG += \
     dbus-1 \


### PR DESCRIPTION
    DBus adaptor source are generated from .xml. Whether those should
    be even included in docs is one thing, but now that they get visible in
    docs, at least try to be consistent between builds.
