### PR TITLE
Implement XDG shell interface

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -36,6 +36,7 @@ BuildRequires:  pkgconfig(libresourceqt5)
 BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(wayland-server)
+BuildRequires:  pkgconfig(wayland-protocols)
 BuildRequires:  pkgconfig(usb-moded-qt5) >= 1.8
 BuildRequires:  pkgconfig(systemsettings) >= 0.8.0
 BuildRequires:  pkgconfig(nemodevicelock)

--- a/src/compositor/compositor.pri
+++ b/src/compositor/compositor.pri
@@ -28,7 +28,9 @@ SOURCES += \
     $$PWD/windowpixmapitem.cpp \
     $$PWD/windowproperty.cpp \
     $$PWD/lipsticksurfaceinterface.cpp \
-    $$PWD/lipstickrecorder.cpp
+    $$PWD/lipstickrecorder.cpp \
+    $$PWD/lipstickviewporter.cpp \
+    $$PWD/lipstickfractionalscale.cpp \
 
 DEFINES += QT_COMPOSITOR_QUICK
 
@@ -37,6 +39,11 @@ QT += compositor
 # needed for hardware compositor
 QT += quick-private gui-private core-private compositor-private qml-private
 
-WAYLANDSERVERSOURCES += ../protocol/lipstick-recorder.xml \
+PROTOCOL_PATH = $$system($$pkgConfigExecutable() --variable=pkgdatadir wayland-protocols)
+
+WAYLANDSERVERSOURCES += \
+    ../protocol/lipstick-recorder.xml \
+    $$PROTOCOL_PATH/stable/viewporter/viewporter.xml \
+    $$PROTOCOL_PATH/staging/fractional-scale/fractional-scale-v1.xml \
 
 OTHER_FILES += $$PWD/compositor.xml $$PWD/fileservice.xml

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -42,6 +42,7 @@
 #include "lipsticksettings.h"
 #include "lipstickrecorder.h"
 #include "alienmanager/alienmanager.h"
+#include "xdgshell/xdgshell.h"
 #include "logging.h"
 
 namespace {
@@ -125,6 +126,7 @@ LipstickCompositor::LipstickCompositor()
     m_recorder = new LipstickRecorderManager;
     addGlobalInterface(m_recorder);
     addGlobalInterface(new AlienManagerGlobal);
+    addGlobalInterface(new XdgShellGlobal);
 
     QObject::connect(m_mceNameOwner, &QMceNameOwner::validChanged,
                      this, &LipstickCompositor::processQueuedSetUpdatesEnabledCalls);

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -41,6 +41,8 @@
 #include "lipstickkeymap.h"
 #include "lipsticksettings.h"
 #include "lipstickrecorder.h"
+#include "lipstickviewporter.h"
+#include "lipstickfractionalscale.h"
 #include "alienmanager/alienmanager.h"
 #include "xdgshell/xdgshell.h"
 #include "logging.h"
@@ -125,6 +127,8 @@ LipstickCompositor::LipstickCompositor()
 
     m_recorder = new LipstickRecorderManager;
     addGlobalInterface(m_recorder);
+    addGlobalInterface(new ViewporterGlobal);
+    addGlobalInterface(new FractionalScaleGlobal);
     addGlobalInterface(new AlienManagerGlobal);
     addGlobalInterface(new XdgShellGlobal);
 
@@ -210,7 +214,6 @@ void LipstickCompositor::surfaceCreated(QWaylandSurface *surface)
 {
     connect(surface, SIGNAL(mapped()), this, SLOT(surfaceMapped()));
     connect(surface, SIGNAL(unmapped()), this, SLOT(surfaceUnmapped()));
-    connect(surface, SIGNAL(sizeChanged()), this, SLOT(surfaceSizeChanged()));
     connect(surface, SIGNAL(titleChanged()), this, SLOT(surfaceTitleChanged()));
     connect(surface, SIGNAL(windowPropertyChanged(QString,QVariant)), this, SLOT(windowPropertyChanged(QString)));
     connect(surface, SIGNAL(raiseRequested()), this, SLOT(surfaceRaised()));
@@ -549,7 +552,6 @@ void LipstickCompositor::surfaceMapped()
         item->setParentItem(contentItem());
     }
 
-    item->setSize(surface->size());
     m_totalWindowCount++;
     m_mappedSurfaces.insert(item->windowId(), item);
 
@@ -566,15 +568,6 @@ void LipstickCompositor::surfaceMapped()
 void LipstickCompositor::surfaceUnmapped()
 {
     surfaceUnmapped(qobject_cast<QWaylandSurface *>(sender()));
-}
-
-void LipstickCompositor::surfaceSizeChanged()
-{
-    QWaylandSurface *surface = qobject_cast<QWaylandSurface *>(sender());
-
-    LipstickCompositorWindow *window = surfaceWindow(surface);
-    if (window)
-        window->setSize(surface->size());
 }
 
 void LipstickCompositor::surfaceTitleChanged()

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -223,7 +223,6 @@ signals:
 private slots:
     void surfaceMapped();
     void surfaceUnmapped();
-    void surfaceSizeChanged();
     void surfaceTitleChanged();
     void surfaceRaised();
     void surfaceLowered();

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -26,6 +26,7 @@
 
 #include "lipstickcompositor.h"
 #include "lipstickcompositorwindow.h"
+#include "lipsticksurfaceinterface.h"
 
 LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &category,
                                                    QWaylandQuickSurface *surface, QQuickItem *parent)
@@ -53,6 +54,8 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
         m_windowClosed = true;
         tryRemove();
     });
+
+    connect(this, &QQuickItem::scaleChanged, this, &LipstickCompositorWindow::handleScaleChanged);
 
     if (surface) {
         m_processId = surface->client()->processId();
@@ -481,6 +484,16 @@ void LipstickCompositorWindow::handleTouchCancel()
     if (QWindow *w = window())
         w->removeEventFilter(this);
     m_interceptingTouch = false;
+}
+
+void LipstickCompositorWindow::handleScaleChanged()
+{
+    QWaylandSurface *m_surface = surface();
+    if (!m_surface)
+        return;
+
+    LipstickScaleOp op(scale());
+    surface()->sendInterfaceOp(op);
 }
 
 void LipstickCompositorWindow::terminateProcess(int killTimeout)

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -105,7 +105,7 @@ private:
     void tryRemove();
     void refreshMouseRegion();
     void refreshGrabbedKeys();
-    void handleTouchEvent(QTouchEvent *e);
+    void handleTouchEvent(QTouchEvent *e, bool intercepted);
 
     void updatePolicyApplicationId();
 

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -73,6 +73,7 @@ public:
 
 protected:
     void itemChange(ItemChange change, const ItemChangeData &data);
+    QSGNode *updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *data);
 
     virtual bool event(QEvent *);
     virtual void mousePressEvent(QMouseEvent *event);
@@ -93,7 +94,8 @@ signals:
 
 private slots:
     void handleTouchCancel();
-    void handleScaleChanged();
+    void updateScale();
+    void updateViewport();
     void killProcess();
 
 private:
@@ -130,6 +132,7 @@ private:
         QList<int> keys;
     } m_pressedGrabbedKeys;
     QVector<QQuickItem *> m_refs;
+    QRectF m_sourceRect;
 };
 
 #endif // LIPSTICKCOMPOSITORWINDOW_H

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -93,6 +93,7 @@ signals:
 
 private slots:
     void handleTouchCancel();
+    void handleScaleChanged();
     void killProcess();
 
 private:

--- a/src/compositor/lipstickfractionalscale.cpp
+++ b/src/compositor/lipstickfractionalscale.cpp
@@ -1,0 +1,98 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include "lipsticksurfaceinterface.h"
+#include "lipstickfractionalscale.h"
+
+FractionalScaleGlobal::FractionalScaleGlobal(QObject *parent)
+    : QObject(parent)
+{
+}
+
+const wl_interface *FractionalScaleGlobal::interface() const
+{
+    return &wp_fractional_scale_manager_v1_interface;
+}
+
+void FractionalScaleGlobal::bind(wl_client *client, uint32_t version, uint32_t id)
+{
+    new FractionalScaleManager(client, version, id, this);
+}
+
+FractionalScaleManager::FractionalScaleManager(wl_client *client, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QtWaylandServer::wp_fractional_scale_manager_v1(client, id, version)
+{
+}
+
+FractionalScaleManager::~FractionalScaleManager()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+void FractionalScaleManager::wp_fractional_scale_manager_v1_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void FractionalScaleManager::wp_fractional_scale_manager_v1_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void FractionalScaleManager::wp_fractional_scale_manager_v1_get_fractional_scale(Resource *resource, uint32_t id, ::wl_resource *surface)
+{
+    Q_UNUSED(resource);
+    QWaylandSurface *surf = QWaylandSurface::fromResource(surface);
+    new FractionalScale(surf, wl_resource_get_version(resource->handle), id, this);
+}
+
+FractionalScale::FractionalScale(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QWaylandSurfaceInterface(surface)
+    , QtWaylandServer::wp_fractional_scale_v1(surface->client()->client(), id, version)
+{
+}
+
+FractionalScale::~FractionalScale()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+bool FractionalScale::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+        case LipstickBufferScaleOp::Type:
+            send_preferred_scale(static_cast<LipstickBufferScaleOp *>(op)->scale() * 120);
+            return true;
+        default:
+            break;
+    }
+    return false;
+}
+
+void FractionalScale::wp_fractional_scale_v1_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void FractionalScale::wp_fractional_scale_v1_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}

--- a/src/compositor/lipstickfractionalscale.h
+++ b/src/compositor/lipstickfractionalscale.h
@@ -1,0 +1,63 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef LIPSTICKFRACTIONALSCALE_H
+#define LIPSTICKFRACTIONALSCALE_H
+
+#include <QObject>
+#include <QtCompositor/QWaylandGlobalInterface>
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-fractional-scale-v1.h"
+
+class QWaylandSurface;
+
+class FractionalScaleGlobal : public QObject, public QWaylandGlobalInterface
+{
+public:
+    explicit FractionalScaleGlobal(QObject *parent = nullptr);
+
+    const wl_interface *interface() const Q_DECL_OVERRIDE;
+    void bind(wl_client *client, uint32_t version, uint32_t id) Q_DECL_OVERRIDE;
+};
+
+class FractionalScaleManager : public QObject, public QtWaylandServer::wp_fractional_scale_manager_v1
+{
+public:
+    FractionalScaleManager(wl_client *client, uint32_t version, uint32_t id, QObject *parent);
+    ~FractionalScaleManager();
+
+protected:
+    void wp_fractional_scale_manager_v1_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void wp_fractional_scale_manager_v1_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void wp_fractional_scale_manager_v1_get_fractional_scale(Resource *resource, uint32_t id, ::wl_resource *surface) Q_DECL_OVERRIDE;
+};
+
+class FractionalScale
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::wp_fractional_scale_v1
+{
+public:
+    FractionalScale(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent);
+    ~FractionalScale();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
+
+    void wp_fractional_scale_v1_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void wp_fractional_scale_v1_destroy(Resource *resource) Q_DECL_OVERRIDE;
+};
+
+#endif

--- a/src/compositor/lipsticksurfaceinterface.cpp
+++ b/src/compositor/lipsticksurfaceinterface.cpp
@@ -19,3 +19,10 @@ LipstickOomScoreOp::LipstickOomScoreOp(int score)
     , m_score(score)
 {
 }
+
+
+LipstickScaleOp::LipstickScaleOp(qreal scale)
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+    , m_scale(scale)
+{
+}

--- a/src/compositor/lipsticksurfaceinterface.cpp
+++ b/src/compositor/lipsticksurfaceinterface.cpp
@@ -26,3 +26,16 @@ LipstickScaleOp::LipstickScaleOp(qreal scale)
     , m_scale(scale)
 {
 }
+
+
+LipstickGetViewportOp::LipstickGetViewportOp()
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+{
+}
+
+
+LipstickBufferScaleOp::LipstickBufferScaleOp(qreal scale)
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+    , m_scale(scale)
+{
+}

--- a/src/compositor/lipsticksurfaceinterface.h
+++ b/src/compositor/lipsticksurfaceinterface.h
@@ -43,4 +43,32 @@ private:
     qreal m_scale;
 };
 
+class LipstickGetViewportOp : public QWaylandSurfaceOp
+{
+public:
+    enum { Type = QWaylandSurfaceOp::UserType + 3 };
+    LipstickGetViewportOp();
+
+    const QRectF &sourceRect() const { return m_sourceRect; }
+    const QSize &destSize() const { return m_destSize; }
+
+private:
+    QRectF m_sourceRect;
+    QSize m_destSize;
+
+    friend class LipstickViewport;
+};
+
+class LipstickBufferScaleOp : public QWaylandSurfaceOp
+{
+public:
+    enum { Type = QWaylandSurfaceOp::UserType + 4 };
+    LipstickBufferScaleOp(qreal scale);
+
+    qreal scale() const { return m_scale; }
+
+private:
+    qreal m_scale;
+};
+
 #endif

--- a/src/compositor/lipsticksurfaceinterface.h
+++ b/src/compositor/lipsticksurfaceinterface.h
@@ -31,4 +31,16 @@ private:
     int m_score;
 };
 
+class LipstickScaleOp : public QWaylandSurfaceOp
+{
+public:
+    enum { Type = QWaylandSurfaceOp::UserType + 2 };
+    LipstickScaleOp(qreal scale);
+
+    qreal scale() const { return m_scale; }
+
+private:
+    qreal m_scale;
+};
+
 #endif

--- a/src/compositor/lipstickviewporter.cpp
+++ b/src/compositor/lipstickviewporter.cpp
@@ -1,0 +1,114 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include "lipsticksurfaceinterface.h"
+#include "lipstickviewporter.h"
+
+ViewporterGlobal::ViewporterGlobal(QObject *parent)
+    : QObject(parent)
+{
+}
+
+const wl_interface *ViewporterGlobal::interface() const
+{
+    return &wp_viewporter_interface;
+}
+
+void ViewporterGlobal::bind(wl_client *client, uint32_t version, uint32_t id)
+{
+    new LipstickViewporter(client, version, id, this);
+}
+
+LipstickViewporter::LipstickViewporter(wl_client *client, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QtWaylandServer::wp_viewporter(client, id, version)
+{
+}
+
+LipstickViewporter::~LipstickViewporter()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+void LipstickViewporter::wp_viewporter_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void LipstickViewporter::wp_viewporter_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void LipstickViewporter::wp_viewporter_get_viewport(Resource *resource, uint32_t id, ::wl_resource *surface)
+{
+    Q_UNUSED(resource);
+    QWaylandSurface *surf = QWaylandSurface::fromResource(surface);
+    new LipstickViewport(surf, wl_resource_get_version(resource->handle), id, this);
+}
+
+LipstickViewport::LipstickViewport(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QWaylandSurfaceInterface(surface)
+    , QtWaylandServer::wp_viewport(surface->client()->client(), id, version)
+{
+}
+
+LipstickViewport::~LipstickViewport()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+bool LipstickViewport::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+        case LipstickGetViewportOp::Type: {
+            LipstickGetViewportOp *vp = static_cast<LipstickGetViewportOp *>(op);
+            vp->m_sourceRect = m_sourceRect;
+            vp->m_destSize = m_destSize;
+            return true;
+        }
+        default:
+            break;
+    }
+    return false;
+}
+
+void LipstickViewport::wp_viewport_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void LipstickViewport::wp_viewport_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void LipstickViewport::wp_viewport_set_source(Resource *resource, wl_fixed_t x, wl_fixed_t y, wl_fixed_t width, wl_fixed_t height)
+{
+    Q_UNUSED(resource);
+    m_sourceRect.setRect(wl_fixed_to_double(x), wl_fixed_to_double(y),
+                         wl_fixed_to_double(width), wl_fixed_to_double(height));
+}
+
+void LipstickViewport::wp_viewport_set_destination(Resource *resource, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource);
+    m_destSize = QSize(width, height);
+}

--- a/src/compositor/lipstickviewporter.h
+++ b/src/compositor/lipstickviewporter.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef LIPSTICKVIEWPORTER_H
+#define LIPSTICKVIEWPORTER_H
+
+#include <QObject>
+#include <QRect>
+#include <QtCompositor/QWaylandGlobalInterface>
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-viewporter.h"
+
+class QWaylandSurface;
+
+class ViewporterGlobal : public QObject, public QWaylandGlobalInterface
+{
+public:
+    explicit ViewporterGlobal(QObject *parent = nullptr);
+
+    const wl_interface *interface() const Q_DECL_OVERRIDE;
+    void bind(wl_client *client, uint32_t version, uint32_t id) Q_DECL_OVERRIDE;
+};
+
+class LipstickViewporter : public QObject, public QtWaylandServer::wp_viewporter
+{
+public:
+    LipstickViewporter(wl_client *client, uint32_t version, uint32_t id, QObject *parent);
+    ~LipstickViewporter();
+
+protected:
+    void wp_viewporter_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void wp_viewporter_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void wp_viewporter_get_viewport(Resource *resource, uint32_t id, ::wl_resource *surface) Q_DECL_OVERRIDE;
+};
+
+class LipstickViewport
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::wp_viewport
+{
+public:
+    LipstickViewport(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent);
+    ~LipstickViewport();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
+
+    void wp_viewport_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void wp_viewport_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void wp_viewport_set_source(Resource *resource, wl_fixed_t x, wl_fixed_t y, wl_fixed_t width, wl_fixed_t height) Q_DECL_OVERRIDE;
+    void wp_viewport_set_destination(Resource *resource, int32_t width, int32_t height) Q_DECL_OVERRIDE;
+
+private:
+    QRectF m_sourceRect;
+    QSize m_destSize;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgpopup.cpp
+++ b/src/compositor/xdgshell/xdgpopup.cpp
@@ -1,0 +1,108 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositorVersion>
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include <private/qwlsurface_p.h>
+
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+#include "xdgpopup.h"
+
+XdgPopup::XdgPopup(XdgSurface *xdgSurface, const QRect &rect, uint32_t version, uint32_t id)
+    : QObject(xdgSurface)
+    , QWaylandSurfaceInterface(xdgSurface->surface())
+    , QtWaylandServer::xdg_popup(surface()->client()->client(), id, version)
+    , m_xdgSurface(xdgSurface)
+    , m_rect(rect)
+{
+    setSurfaceType(QWaylandSurface::Popup);
+
+    XdgSurface *xdgParent = xdgSurface->xdgParent();
+    surface()->handle()->setTransientParent(xdgParent->surface()->handle());
+    updateOffset();
+    sendConfigure();
+
+    connect(xdgParent, &XdgSurface::geometryChanged, this, &XdgPopup::updateOffset);
+    connect(xdgSurface, &XdgSurface::geometryChanged, this, &XdgPopup::updateOffset);
+    connect(surface(), &QWaylandSurface::configure, this, &XdgPopup::configure);
+}
+
+XdgPopup::~XdgPopup()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+    surface()->setMapped(false);
+    m_xdgSurface->roleDestroyed();
+}
+
+bool XdgPopup::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+        case QWaylandSurfaceOp::Close:
+            send_popup_done();
+            return true;
+        case QWaylandSurfaceOp::Ping:
+            m_xdgSurface->manager()->ping(static_cast<QWaylandSurfacePingOp *>(op)->serial(), surface());
+            return true;
+        default:
+            break;
+    }
+    return false;
+}
+
+void XdgPopup::xdg_popup_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void XdgPopup::xdg_popup_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgPopup::xdg_popup_reposition(Resource *resource, ::wl_resource *positioner, uint32_t token)
+{
+    Q_UNUSED(resource);
+    m_rect = XdgPositioner::fromResource(positioner)->toRect(m_xdgSurface->xdgParent());
+    updateOffset();
+    send_repositioned(token);
+    sendConfigure();
+}
+
+void XdgPopup::configure(bool hasBuffer)
+{
+    surface()->setMapped(hasBuffer);
+}
+
+void XdgPopup::updateOffset()
+{
+    const QRect &geometry = m_xdgSurface->geometry();
+    const QRect &parentGeometry = m_xdgSurface->xdgParent()->geometry();
+
+    int x = parentGeometry.left() + m_rect.left() - geometry.left();
+    int y = parentGeometry.top() + m_rect.top() - geometry.top();
+
+    surface()->handle()->setTransientOffset(x, y);
+}
+
+void XdgPopup::sendConfigure()
+{
+    send_configure(m_rect.left(), m_rect.top(), m_rect.width(), m_rect.height());
+    m_xdgSurface->sendConfigure();
+}

--- a/src/compositor/xdgshell/xdgpopup.h
+++ b/src/compositor/xdgshell/xdgpopup.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGPOPUP_H
+#define XDGPOPUP_H
+
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgSurface;
+
+class XdgPopup
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::xdg_popup
+{
+public:
+    XdgPopup(XdgSurface *xdgSurface, const QRect &rect, uint32_t version, uint32_t id);
+    ~XdgPopup();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
+
+    void xdg_popup_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_popup_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_popup_reposition(Resource *resource, ::wl_resource *positioner, uint32_t token) Q_DECL_OVERRIDE;
+
+private:
+    void updateOffset();
+    void configure(bool hasBuffer);
+    void sendConfigure();
+
+    XdgSurface *m_xdgSurface;
+    QRect m_rect;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgpositioner.cpp
+++ b/src/compositor/xdgshell/xdgpositioner.cpp
@@ -1,0 +1,276 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include "lipstickcompositor.h"
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+#include "xdgtoplevel.h"
+
+XdgPositioner::XdgPositioner(XdgShell *mgr, wl_client *client, uint32_t version, uint32_t id)
+    : QObject(mgr)
+    , QtWaylandServer::xdg_positioner(client, id, version)
+    , m_anchor(0)
+    , m_gravity(0)
+    , m_adjustment(XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_NONE)
+{
+}
+
+XdgPositioner::~XdgPositioner()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+XdgPositioner *XdgPositioner::fromResource(::wl_resource *resource)
+{
+    return static_cast<XdgPositioner *>(Resource::fromResource(resource)->xdg_positioner_object);
+}
+
+QRect XdgPositioner::toRect(const XdgSurface *surface) const
+{
+    if (m_size.isNull() || m_anchorRect.isNull())
+        return QRect();
+
+    QPointF offset(0.0, 0.0);
+    XdgToplevel *top = surface->findToplevel(&offset);
+    if (!top)
+        return QRect();
+
+    LipstickCompositor *compositor = LipstickCompositor::instance();
+    QSize size = QSize(compositor->width(), compositor->height());
+    QRect bounds = QRect(offset.toPoint(), size);
+
+    uint32_t adjustment = m_adjustment;
+    Qt::Edges anchor, gravity;
+    Qt::Orientations flip = 0;
+
+    QRect rect;
+
+    for (;;) {
+        int x = m_offset.x(), y = m_offset.y();
+
+        anchor = flipEdges(m_anchor, flip);
+        gravity = flipEdges(m_gravity, flip);
+
+        if (anchor & Qt::TopEdge) {
+            y += m_anchorRect.top();
+        } else if (anchor & Qt::BottomEdge) {
+            y += m_anchorRect.bottom() + 1;
+        } else {
+            y += m_anchorRect.top() + m_anchorRect.height() / 2;
+        }
+
+        if (anchor & Qt::LeftEdge) {
+            x += m_anchorRect.left();
+        } else if (anchor & Qt::RightEdge) {
+            x += m_anchorRect.right() + 1;
+        } else {
+            x += m_anchorRect.left() + m_anchorRect.width() / 2;
+        }
+
+        if (gravity & Qt::TopEdge) {
+            y -= m_size.height();
+        } else if (!(m_gravity & Qt::BottomEdge)) {
+            y -= m_size.height() / 2;
+        }
+
+        if (gravity & Qt::LeftEdge) {
+            x -= m_size.width();
+        } else if (!(gravity & Qt::RightEdge)) {
+            x -= m_size.width() / 2;
+        }
+
+        rect.setRect(x, y, m_size.width(), m_size.height());
+
+        // If the surface is contrained on a flippable axis, invert the anchor
+        // and gravity on that axis and try again. If this is the second
+        // attempt, revert to the original position.
+
+        if (rect.left() < bounds.left() || rect.right() > bounds.right()) {
+            if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X) {
+                adjustment &= ~XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X;
+                flip |= Qt::Horizontal;
+                continue;
+            } else if (flip & Qt::Horizontal) {
+                flip &= ~Qt::Horizontal;
+                continue;
+            }
+        }
+
+        if (rect.top() < bounds.top() || rect.bottom() > bounds.bottom()) {
+            if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y) {
+                adjustment &= ~XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y;
+                flip |= Qt::Vertical;
+                continue;
+            } else if (flip & Qt::Vertical) {
+                flip &= ~Qt::Vertical;
+                continue;
+            }
+        }
+
+        // If no flips are left to try, proceed with other options.
+        break;
+    }
+
+    // Try to move the surface so that at least one edge is unconstrained.
+    // Prefer movement in direction of gravity.
+
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X) {
+        if (gravity & Qt::LeftEdge) {
+            if (rect.left() < bounds.left()) {
+                rect.moveLeft(bounds.left());
+            }
+        }
+        if (rect.right() > bounds.right()) {
+            rect.moveRight(bounds.right());
+        }
+        if (!(gravity & Qt::LeftEdge)) {
+            if (rect.left() < bounds.left()) {
+                rect.moveLeft(bounds.left());
+            }
+        }
+    }
+
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y) {
+        if (gravity & Qt::TopEdge) {
+            if (rect.top() < bounds.top()) {
+                rect.moveTop(bounds.top());
+            }
+        }
+        if (rect.bottom() > bounds.bottom()) {
+            rect.moveBottom(bounds.bottom());
+        }
+        if (!(gravity & Qt::TopEdge)) {
+            if (rect.top() < bounds.top()) {
+                rect.moveTop(bounds.top());
+            }
+        }
+    }
+
+    // If allowed, resize the surface to make it unconstrained.
+    QRect resized = bounds & rect;
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_X) {
+        rect.setLeft(resized.left());
+        rect.setRight(resized.right());
+    }
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_Y) {
+        rect.setTop(resized.top());
+        rect.setBottom(resized.bottom());
+    }
+
+    return rect;
+}
+
+void XdgPositioner::xdg_positioner_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void XdgPositioner::xdg_positioner_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgPositioner::xdg_positioner_set_size(Resource *resource, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource);
+    m_size = QSize(width, height);
+}
+
+void XdgPositioner::xdg_positioner_set_anchor_rect(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource);
+    m_anchorRect.setRect(x, y, width, height);
+}
+
+void XdgPositioner::xdg_positioner_set_anchor(Resource *resource, uint32_t anchor)
+{
+    Q_UNUSED(resource);
+    m_anchor = toEdges(anchor);
+}
+
+void XdgPositioner::xdg_positioner_set_gravity(Resource *resource, uint32_t gravity)
+{
+    Q_UNUSED(resource);
+    m_gravity = toEdges(gravity);
+}
+
+void XdgPositioner::xdg_positioner_set_constraint_adjustment(Resource *resource, uint32_t adjustment)
+{
+    Q_UNUSED(resource);
+    m_adjustment = adjustment;
+}
+
+void XdgPositioner::xdg_positioner_set_offset(Resource *resource, int32_t x, int32_t y)
+{
+    Q_UNUSED(resource);
+    m_offset = QPoint(x, y);
+}
+
+Qt::Edges XdgPositioner::toEdges(uint32_t anchor)
+{
+    Qt::Edges edges = 0;
+
+    if (anchor == XDG_POSITIONER_ANCHOR_TOP ||
+            anchor == XDG_POSITIONER_ANCHOR_TOP_LEFT ||
+            anchor == XDG_POSITIONER_ANCHOR_TOP_RIGHT) {
+        edges |= Qt::TopEdge;
+    }
+
+    if (anchor == XDG_POSITIONER_ANCHOR_BOTTOM ||
+            anchor == XDG_POSITIONER_ANCHOR_BOTTOM_LEFT ||
+            anchor == XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT) {
+        edges |= Qt::BottomEdge;
+    }
+
+    if (anchor == XDG_POSITIONER_ANCHOR_LEFT ||
+            anchor == XDG_POSITIONER_ANCHOR_TOP_LEFT ||
+            anchor == XDG_POSITIONER_ANCHOR_BOTTOM_LEFT) {
+        edges |= Qt::LeftEdge;
+    }
+
+    if (anchor == XDG_POSITIONER_ANCHOR_RIGHT ||
+            anchor == XDG_POSITIONER_ANCHOR_TOP_RIGHT ||
+            anchor == XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT) {
+        edges |= Qt::RightEdge;
+    }
+
+    return edges;
+}
+
+Qt::Edges XdgPositioner::flipEdges(Qt::Edges edges, Qt::Orientations flip)
+{
+    Qt::Edges transformed = 0;
+
+    if (flip & Qt::Vertical) {
+        if (edges & Qt::TopEdge)
+            transformed |= Qt::BottomEdge;
+        if (edges & Qt::BottomEdge)
+            transformed |= Qt::TopEdge;
+    } else {
+        transformed |= edges & (Qt::TopEdge | Qt::BottomEdge);
+    }
+
+    if (flip & Qt::Horizontal) {
+        if (edges & Qt::LeftEdge)
+            transformed |= Qt::RightEdge;
+        if (edges & Qt::RightEdge)
+            transformed |= Qt::LeftEdge;
+    } else {
+        transformed |= edges & (Qt::LeftEdge | Qt::RightEdge);
+    }
+
+    return transformed;
+}

--- a/src/compositor/xdgshell/xdgpositioner.cpp
+++ b/src/compositor/xdgshell/xdgpositioner.cpp
@@ -48,8 +48,8 @@ QRect XdgPositioner::toRect(const XdgSurface *surface) const
         return QRect();
 
     LipstickCompositor *compositor = LipstickCompositor::instance();
-    QSize size = QSize(compositor->width(), compositor->height());
-    QRect bounds = QRect(offset.toPoint(), size);
+    QSizeF size = QSizeF(compositor->width(), compositor->height()) / top->scale();
+    QRect bounds = QRectF(offset, size).toRect();
 
     uint32_t adjustment = m_adjustment;
     Qt::Edges anchor, gravity;

--- a/src/compositor/xdgshell/xdgpositioner.h
+++ b/src/compositor/xdgshell/xdgpositioner.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGPOSITIONER_H
+#define XDGPOSITIONER_H
+
+#include <QObject>
+#include <QRect>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgShell;
+class XdgSurface;
+
+class XdgPositioner : public QObject, public QtWaylandServer::xdg_positioner
+{
+public:
+    XdgPositioner(XdgShell *mgr, wl_client *client, uint32_t version, uint32_t id);
+    ~XdgPositioner();
+
+    static XdgPositioner *fromResource(::wl_resource *resource);
+
+    QRect toRect(const XdgSurface *surface) const;
+
+protected:
+    void xdg_positioner_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_positioner_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_positioner_set_size(Resource *resource, int32_t width, int32_t height) Q_DECL_OVERRIDE;
+    void xdg_positioner_set_anchor_rect(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height) Q_DECL_OVERRIDE;
+    void xdg_positioner_set_anchor(Resource *resource, uint32_t anchor) Q_DECL_OVERRIDE;
+    void xdg_positioner_set_gravity(Resource *resource, uint32_t gravity) Q_DECL_OVERRIDE;
+    void xdg_positioner_set_constraint_adjustment(Resource *resource, uint32_t adjustment) Q_DECL_OVERRIDE;
+    void xdg_positioner_set_offset(Resource *resource, int32_t x, int32_t y) Q_DECL_OVERRIDE;
+
+private:
+    static Qt::Edges toEdges(uint32_t anchor);
+    static Qt::Edges flipEdges(Qt::Edges edges, Qt::Orientations flip);
+
+    QSize m_size;
+    QRect m_anchorRect;
+    Qt::Edges m_anchor;
+    Qt::Edges m_gravity;
+    uint32_t m_adjustment;
+    QPoint m_offset;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgshell.cpp
+++ b/src/compositor/xdgshell/xdgshell.cpp
@@ -1,0 +1,81 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandSurface>
+
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+
+XdgShellGlobal::XdgShellGlobal(QObject *parent)
+    : QObject(parent)
+{
+}
+
+const wl_interface *XdgShellGlobal::interface() const
+{
+    return &xdg_wm_base_interface;
+}
+
+void XdgShellGlobal::bind(wl_client *client, uint32_t version, uint32_t id)
+{
+    new XdgShell(client, version, id, this);
+}
+
+XdgShell::XdgShell(wl_client *client, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QtWaylandServer::xdg_wm_base(client, id, version)
+{
+}
+
+XdgShell::~XdgShell()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+void XdgShell::ping(uint32_t serial, QWaylandSurface *surface)
+{
+    m_pings.insert(serial, surface);
+    send_ping(serial);
+}
+
+void XdgShell::xdg_wm_base_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void XdgShell::xdg_wm_base_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgShell::xdg_wm_base_create_positioner(Resource *resource, uint32_t id)
+{
+    new XdgPositioner(this, resource->client(), wl_resource_get_version(resource->handle), id);
+}
+
+void XdgShell::xdg_wm_base_get_xdg_surface(Resource *resource, uint32_t id, ::wl_resource *surface)
+{
+    QWaylandSurface *surf = QWaylandSurface::fromResource(surface);
+    new XdgSurface(this, surf, wl_resource_get_version(resource->handle), id);
+}
+
+void XdgShell::xdg_wm_base_pong(Resource *resource, uint32_t serial)
+{
+    Q_UNUSED(resource)
+    QWaylandSurface *surf = m_pings.value(serial);
+    if (surf)
+        surf->pong();
+}

--- a/src/compositor/xdgshell/xdgshell.h
+++ b/src/compositor/xdgshell/xdgshell.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGSHELL_H
+#define XDGSHELL_H
+
+#include <QObject>
+#include <QtCompositor/QWaylandGlobalInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgShellGlobal : public QObject, public QWaylandGlobalInterface
+{
+public:
+    explicit XdgShellGlobal(QObject *parent = nullptr);
+
+    const wl_interface *interface() const Q_DECL_OVERRIDE;
+    void bind(wl_client *client, uint32_t version, uint32_t id) Q_DECL_OVERRIDE;
+};
+
+class XdgShell : public QObject, public QtWaylandServer::xdg_wm_base
+{
+public:
+    XdgShell(wl_client *client, uint32_t version, uint32_t id, QObject *parent);
+    ~XdgShell();
+
+    void ping(uint32_t serial, QWaylandSurface *surface);
+
+protected:
+    void xdg_wm_base_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_wm_base_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_wm_base_create_positioner(Resource *resource, uint32_t id) Q_DECL_OVERRIDE;
+    void xdg_wm_base_get_xdg_surface(Resource *resource, uint32_t id, ::wl_resource *surface) Q_DECL_OVERRIDE;
+    void xdg_wm_base_pong(Resource *resource, uint32_t serial) Q_DECL_OVERRIDE;
+
+private:
+    QMap<uint32_t, QWaylandSurface *> m_pings;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgshell.pri
+++ b/src/compositor/xdgshell/xdgshell.pri
@@ -1,0 +1,21 @@
+INCLUDEPATH += $$PWD
+
+HEADERS += \
+    $$PWD/xdgshell.h \
+    $$PWD/xdgpositioner.h \
+    $$PWD/xdgsurface.h \
+    $$PWD/xdgtoplevel.h \
+    $$PWD/xdgpopup.h \
+
+SOURCES += \
+    $$PWD/xdgshell.cpp \
+    $$PWD/xdgpositioner.cpp \
+    $$PWD/xdgsurface.cpp \
+    $$PWD/xdgtoplevel.cpp \
+    $$PWD/xdgpopup.cpp \
+
+PROTOCOL_PATH = $$system($$pkgConfigExecutable() --variable=pkgdatadir wayland-protocols)
+
+WAYLANDSERVERSOURCES += $$PROTOCOL_PATH/stable/xdg-shell/xdg-shell.xml \
+
+QT += compositor

--- a/src/compositor/xdgshell/xdgsurface.cpp
+++ b/src/compositor/xdgshell/xdgsurface.cpp
@@ -1,0 +1,150 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandCompositor>
+#include <QtCompositor/QWaylandSurface>
+
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+#include "xdgtoplevel.h"
+#include "xdgpopup.h"
+
+XdgSurface::XdgSurface(XdgShell *mgr, QWaylandSurface *surface, uint32_t version, uint32_t id)
+    : QObject(mgr)
+    , QWaylandSurfaceInterface(surface)
+    , QtWaylandServer::xdg_surface(surface->client()->client(), id, version)
+    , m_manager(mgr)
+    , m_xdgParent(nullptr)
+    , m_toplevel(nullptr)
+    , m_serial(0)
+{
+    connect(surface, &QWaylandSurface::configure, this, &XdgSurface::handleCommit);
+}
+
+XdgSurface::~XdgSurface()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+XdgShell *XdgSurface::manager() const
+{
+    return m_manager;
+}
+
+uint32_t XdgSurface::serial() const
+{
+    return m_serial;
+}
+
+XdgSurface *XdgSurface::xdgParent() const
+{
+    return m_xdgParent;
+}
+
+const QRect& XdgSurface::geometry() const
+{
+    return m_geometry;
+}
+
+XdgToplevel *XdgSurface::findToplevel(QPointF *offset) const
+{
+    if (m_toplevel) {
+        return m_toplevel;
+    }
+
+    if (m_xdgParent) {
+        *offset -= surface()->transientOffset();
+        return m_xdgParent->findToplevel(offset);
+    }
+
+    return nullptr;
+}
+
+void XdgSurface::sendConfigure()
+{
+    m_serial = wl_display_next_serial(surface()->compositor()->waylandDisplay());
+    send_configure(m_serial);
+}
+
+void XdgSurface::roleDestroyed()
+{
+    setParent(m_manager);
+    m_xdgParent = nullptr;
+    m_toplevel = nullptr;
+    m_geometry = QRect();
+    m_pendingGeometry = QRect();
+}
+
+bool XdgSurface::runOperation(QWaylandSurfaceOp *op)
+{
+    Q_UNUSED(op);
+    return false;
+}
+
+void XdgSurface::xdg_surface_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void XdgSurface::xdg_surface_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgSurface::xdg_surface_get_toplevel(Resource *resource, uint32_t id)
+{
+    if (m_xdgParent || m_toplevel)
+        return;
+
+    m_toplevel = new XdgToplevel(this, wl_resource_get_version(resource->handle), id);
+}
+
+void XdgSurface::xdg_surface_get_popup(Resource *resource, uint32_t id, ::wl_resource *parent, ::wl_resource *positioner)
+{
+    Q_UNUSED(resource);
+
+    if (!parent || m_xdgParent || m_toplevel)
+        return;
+
+    m_xdgParent = static_cast<XdgSurface *>(Resource::fromResource(parent)->xdg_surface_object);
+    setParent(m_xdgParent);
+
+    QRect pos = XdgPositioner::fromResource(positioner)->toRect(m_xdgParent);
+    new XdgPopup(this, pos, wl_resource_get_version(resource->handle), id);
+}
+
+void XdgSurface::xdg_surface_set_window_geometry(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource);
+    m_pendingGeometry.setRect(x, y, width, height);
+}
+
+void XdgSurface::xdg_surface_ack_configure(Resource *resource, uint32_t serial)
+{
+    Q_UNUSED(resource);
+    if (serial == m_serial) {
+        m_serial = 0;
+    }
+}
+
+void XdgSurface::handleCommit()
+{
+    if (m_geometry != m_pendingGeometry) {
+        m_geometry = m_pendingGeometry;
+        emit geometryChanged();
+    }
+}

--- a/src/compositor/xdgshell/xdgsurface.h
+++ b/src/compositor/xdgshell/xdgsurface.h
@@ -44,6 +44,8 @@ public:
 
     XdgToplevel *findToplevel(QPointF *offset) const;
 
+    void setPreferredScale(qreal scale);
+
     void sendConfigure();
     void roleDestroyed();
 
@@ -69,6 +71,7 @@ private:
     XdgToplevel *m_toplevel;
     QRect m_pendingGeometry;
     QRect m_geometry;
+    qreal m_preferredScale;
     uint32_t m_serial;
 };
 

--- a/src/compositor/xdgshell/xdgsurface.h
+++ b/src/compositor/xdgshell/xdgsurface.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGSURFACE_H
+#define XDGSURFACE_H
+
+#include <QObject>
+#include <QRect>
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class QWaylandSurface;
+
+class XdgShell;
+class XdgToplevel;
+
+class XdgSurface
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::xdg_surface
+{
+    Q_OBJECT
+
+public:
+    XdgSurface(XdgShell *mgr, QWaylandSurface *surface, uint32_t version, uint32_t id);
+    ~XdgSurface();
+
+    XdgShell *manager() const;
+    uint32_t serial() const;
+    XdgSurface *xdgParent() const;
+    const QRect& geometry() const;
+
+    XdgToplevel *findToplevel(QPointF *offset) const;
+
+    void sendConfigure();
+    void roleDestroyed();
+
+signals:
+    void geometryChanged();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
+
+    void xdg_surface_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_surface_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_surface_get_toplevel(Resource *resource, uint32_t id) Q_DECL_OVERRIDE;
+    void xdg_surface_get_popup(Resource *resource, uint32_t id, ::wl_resource *parent, ::wl_resource *positioner) Q_DECL_OVERRIDE;
+    void xdg_surface_set_window_geometry(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height) Q_DECL_OVERRIDE;
+    void xdg_surface_ack_configure(Resource *resource, uint32_t serial) Q_DECL_OVERRIDE;
+
+private slots:
+    void handleCommit();
+
+private:
+    XdgShell *m_manager;
+    XdgSurface *m_xdgParent;
+    XdgToplevel *m_toplevel;
+    QRect m_pendingGeometry;
+    QRect m_geometry;
+    uint32_t m_serial;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgtoplevel.cpp
+++ b/src/compositor/xdgshell/xdgtoplevel.cpp
@@ -1,0 +1,132 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositorVersion>
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include "lipstickcompositor.h"
+#include "lipsticksurfaceinterface.h"
+#include "xdgshell.h"
+#include "xdgsurface.h"
+#include "xdgtoplevel.h"
+
+XdgToplevel::XdgToplevel(XdgSurface *xdgSurface, uint32_t version, uint32_t id)
+    : QObject(xdgSurface)
+    , QWaylandSurfaceInterface(xdgSurface->surface())
+    , QtWaylandServer::xdg_toplevel(surface()->client()->client(), id, version)
+    , m_xdgSurface(xdgSurface)
+    , m_hidden(false)
+    , m_coverized(false)
+{
+    setSurfaceType(QWaylandSurface::Toplevel);
+
+    LipstickCompositor *compositor = LipstickCompositor::instance();
+    m_size = QSize(compositor->width(), compositor->height());
+    sendConfigure();
+
+    connect(xdgSurface, &XdgSurface::geometryChanged, this, &XdgToplevel::geometryChanged);
+    connect(surface(), &QWaylandSurface::configure, this, &XdgToplevel::configure);
+}
+
+XdgToplevel::~XdgToplevel()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+    surface()->setMapped(false);
+    m_xdgSurface->roleDestroyed();
+}
+
+bool XdgToplevel::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+        case QWaylandSurfaceOp::Close:
+            send_close();
+            return true;
+        case QWaylandSurfaceOp::SetVisibility: {
+            QWindow::Visibility v = static_cast<QWaylandSurfaceSetVisibilityOp *>(op)->visibility();
+            m_hidden = v == QWindow::Hidden;
+            m_coverized = v == QWindow::Minimized;
+            sendConfigure();
+            return true;
+        }
+        case QWaylandSurfaceOp::Ping:
+            m_xdgSurface->manager()->ping(static_cast<QWaylandSurfacePingOp *>(op)->serial(), surface());
+            return true;
+        case QWaylandSurfaceOp::Resize:
+            m_size = static_cast<QWaylandSurfaceResizeOp *>(op)->size();
+            sendConfigure();
+            return true;
+        default:
+            break;
+    }
+    return false;
+}
+
+void XdgToplevel::xdg_toplevel_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource);
+    delete this;
+}
+
+void XdgToplevel::xdg_toplevel_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgToplevel::xdg_toplevel_set_title(Resource *resource, const QString &title)
+{
+    Q_UNUSED(resource);
+    setSurfaceTitle(title);
+}
+
+void XdgToplevel::xdg_toplevel_set_app_id(Resource *resource, const QString &appId)
+{
+    Q_UNUSED(resource);
+    setSurfaceClassName(appId);
+}
+
+void XdgToplevel::xdg_toplevel_set_minimized(Resource *resource)
+{
+    Q_UNUSED(resource);
+    emit surface()->lowerRequested();
+}
+
+void XdgToplevel::configure(bool hasBuffer)
+{
+    if (hasBuffer && m_xdgSurface->geometry().isNull()) {
+        m_size = surface()->size();
+    }
+    surface()->setMapped(hasBuffer);
+}
+
+void XdgToplevel::sendConfigure()
+{
+    QVector<uint32_t> states;
+    states << XDG_TOPLEVEL_STATE_MAXIMIZED;
+    if (!m_coverized && !m_hidden) {
+        states << XDG_TOPLEVEL_STATE_ACTIVATED;
+    }
+    QByteArray data = QByteArray::fromRawData((char *)states.data(), states.size() * sizeof(uint32_t));
+
+    send_configure(m_size.width(), m_size.height(), data);
+    m_xdgSurface->sendConfigure();
+}
+
+void XdgToplevel::geometryChanged()
+{
+    if (m_xdgSurface->geometry().isValid()) {
+        m_size = m_xdgSurface->geometry().size();
+    }
+}

--- a/src/compositor/xdgshell/xdgtoplevel.cpp
+++ b/src/compositor/xdgshell/xdgtoplevel.cpp
@@ -76,6 +76,7 @@ bool XdgToplevel::runOperation(QWaylandSurfaceOp *op)
             return true;
         case LipstickScaleOp::Type:
             m_scale = static_cast<LipstickScaleOp *>(op)->scale();
+            m_xdgSurface->setPreferredScale(m_scale);
             sendConfigure();
             return true;
         default:

--- a/src/compositor/xdgshell/xdgtoplevel.h
+++ b/src/compositor/xdgshell/xdgtoplevel.h
@@ -30,6 +30,8 @@ public:
     XdgToplevel(XdgSurface *xdgSurface, uint32_t version, uint32_t id);
     ~XdgToplevel();
 
+    qreal scale() const;
+
 protected:
     bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
 
@@ -48,6 +50,7 @@ private:
     bool m_hidden;
     bool m_coverized;
     QSize m_size;
+    qreal m_scale;
 };
 
 #endif

--- a/src/compositor/xdgshell/xdgtoplevel.h
+++ b/src/compositor/xdgshell/xdgtoplevel.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Affe Null <affenull2345@gmail.com>
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGTOPLEVEL_H
+#define XDGTOPLEVEL_H
+
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgSurface;
+
+class XdgToplevel
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::xdg_toplevel
+{
+public:
+    XdgToplevel(XdgSurface *xdgSurface, uint32_t version, uint32_t id);
+    ~XdgToplevel();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
+
+    void xdg_toplevel_destroy_resource(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_toplevel_destroy(Resource *resource) Q_DECL_OVERRIDE;
+    void xdg_toplevel_set_title(Resource *resource, const QString &title) Q_DECL_OVERRIDE;
+    void xdg_toplevel_set_app_id(Resource *resource, const QString &appId) Q_DECL_OVERRIDE;
+    void xdg_toplevel_set_minimized(Resource *resource) Q_DECL_OVERRIDE;
+
+private:
+    void geometryChanged();
+    void configure(bool hasBuffer);
+    void sendConfigure();
+
+    XdgSurface *m_xdgSurface;
+    bool m_hidden;
+    bool m_coverized;
+    QSize m_size;
+};
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -24,6 +24,7 @@ INCLUDEPATH += utilities touchscreen components xtools 3rdparty devicestate
 
 include(compositor/compositor.pri)
 include(compositor/alienmanager/alienmanager.pri)
+include(compositor/xdgshell/xdgshell.pri)
 
 PUBLICHEADERS += \
     utilities/qobjectlistmodel.h \

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -56,7 +56,6 @@ public:
     virtual QWaylandSurface *surfaceForId(int) const;
     virtual void surfaceMapped();
     virtual void surfaceUnmapped();
-    virtual void surfaceSizeChanged();
     virtual void surfaceTitleChanged();
     virtual void surfaceRaised();
     virtual void surfaceLowered();
@@ -276,11 +275,6 @@ void LipstickCompositorStub::surfaceMapped()
 void LipstickCompositorStub::surfaceUnmapped()
 {
     stubMethodEntered("surfaceUnmapped");
-}
-
-void LipstickCompositorStub::surfaceSizeChanged()
-{
-    stubMethodEntered("surfaceSizeChanged");
 }
 
 void LipstickCompositorStub::surfaceTitleChanged()
@@ -565,11 +559,6 @@ void LipstickCompositor::surfaceMapped()
 void LipstickCompositor::surfaceUnmapped()
 {
     gLipstickCompositorStub->surfaceUnmapped();
-}
-
-void LipstickCompositor::surfaceSizeChanged()
-{
-    gLipstickCompositorStub->surfaceSizeChanged();
 }
 
 void LipstickCompositor::surfaceTitleChanged()


### PR DESCRIPTION
Add an XDG shell extension similar to the existing AlienManager.

Tested with `weston-demo` from https://build.sailfishos.org/package/show/home:simonschmeisser:wayland/weston and a few GTK-based apps via Flatpak.

With all the apps I tested, the UI appears very small unless it is scaled, making them almost impossible to use on a touchscreen. GTK expects the Wayland compositor to take care of the scaling, so I also implemented a way to override the scale while preserving the window size. It only works on XDG shell surfaces at the moment and can be controlled from QML like this:
```
window.transformOrigin = Item.TopLeft
window.scale = 2
```
This way, the actual scaling decisions can be made in the home screen, which is useful since different apps/devices may need different scaling configurations.

I'm not quite sure about the following points and would appreciate some feedback:
 - Where to put the new custom surface operations: `lipsticksurfaceinterface.h` is a public header, but unlike the existing `LipstickOomScoreOp`, the new operations are private and should only be used inside Lipstick.
 - <del>Whether the Wayland protocols should be added here or taken from the `wayland-protocols` package instead. (How can this be done with qmake?)</del>