### PR TITLE
 Implement xdg-shell interface (second version)

### DIFF
--- a/rpm/lipstick-qt5.spec
+++ b/rpm/lipstick-qt5.spec
@@ -36,6 +36,7 @@ BuildRequires:  pkgconfig(libresourceqt5)
 BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(wayland-server)
+BuildRequires:  pkgconfig(wayland-protocols)
 BuildRequires:  pkgconfig(usb-moded-qt5) >= 1.8
 BuildRequires:  pkgconfig(systemsettings) >= 0.8.0
 BuildRequires:  pkgconfig(nemodevicelock)

--- a/src/compositor/compositor.pri
+++ b/src/compositor/compositor.pri
@@ -28,7 +28,9 @@ SOURCES += \
     $$PWD/windowpixmapitem.cpp \
     $$PWD/windowproperty.cpp \
     $$PWD/lipsticksurfaceinterface.cpp \
-    $$PWD/lipstickrecorder.cpp
+    $$PWD/lipstickrecorder.cpp \
+    $$PWD/lipstickviewporter.cpp \
+    $$PWD/lipstickfractionalscale.cpp \
 
 DEFINES += QT_COMPOSITOR_QUICK
 
@@ -37,6 +39,11 @@ QT += compositor
 # needed for hardware compositor
 QT += quick-private gui-private core-private compositor-private qml-private
 
-WAYLANDSERVERSOURCES += ../protocol/lipstick-recorder.xml \
+PROTOCOL_PATH = $$system($$pkgConfigExecutable() --variable=pkgdatadir wayland-protocols)
+
+WAYLANDSERVERSOURCES += \
+    ../protocol/lipstick-recorder.xml \
+    $$PROTOCOL_PATH/stable/viewporter/viewporter.xml \
+    $$PROTOCOL_PATH/staging/fractional-scale/fractional-scale-v1.xml \
 
 OTHER_FILES += $$PWD/compositor.xml $$PWD/fileservice.xml

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -42,6 +42,7 @@
 #include "lipsticksettings.h"
 #include "lipstickrecorder.h"
 #include "alienmanager/alienmanager.h"
+#include "xdgshell/xdgshell.h"
 #include "logging.h"
 
 namespace {
@@ -125,6 +126,7 @@ LipstickCompositor::LipstickCompositor()
     m_recorder = new LipstickRecorderManager;
     addGlobalInterface(m_recorder);
     addGlobalInterface(new AlienManagerGlobal);
+    addGlobalInterface(new XdgShellGlobal);
 
     QObject::connect(m_mceNameOwner, &QMceNameOwner::validChanged,
                      this, &LipstickCompositor::processQueuedSetUpdatesEnabledCalls);

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -41,6 +41,8 @@
 #include "lipstickkeymap.h"
 #include "lipsticksettings.h"
 #include "lipstickrecorder.h"
+#include "lipstickviewporter.h"
+#include "lipstickfractionalscale.h"
 #include "alienmanager/alienmanager.h"
 #include "xdgshell/xdgshell.h"
 #include "logging.h"
@@ -125,6 +127,8 @@ LipstickCompositor::LipstickCompositor()
 
     m_recorder = new LipstickRecorderManager;
     addGlobalInterface(m_recorder);
+    addGlobalInterface(new ViewporterGlobal);
+    addGlobalInterface(new FractionalScaleGlobal);
     addGlobalInterface(new AlienManagerGlobal);
     addGlobalInterface(new XdgShellGlobal);
 
@@ -210,7 +214,6 @@ void LipstickCompositor::surfaceCreated(QWaylandSurface *surface)
 {
     connect(surface, SIGNAL(mapped()), this, SLOT(surfaceMapped()));
     connect(surface, SIGNAL(unmapped()), this, SLOT(surfaceUnmapped()));
-    connect(surface, SIGNAL(sizeChanged()), this, SLOT(surfaceSizeChanged()));
     connect(surface, SIGNAL(titleChanged()), this, SLOT(surfaceTitleChanged()));
     connect(surface, SIGNAL(windowPropertyChanged(QString,QVariant)), this, SLOT(windowPropertyChanged(QString)));
     connect(surface, SIGNAL(raiseRequested()), this, SLOT(surfaceRaised()));
@@ -549,7 +552,6 @@ void LipstickCompositor::surfaceMapped()
         item->setParentItem(contentItem());
     }
 
-    item->setSize(surface->size());
     m_totalWindowCount++;
     m_mappedSurfaces.insert(item->windowId(), item);
 
@@ -566,15 +568,6 @@ void LipstickCompositor::surfaceMapped()
 void LipstickCompositor::surfaceUnmapped()
 {
     surfaceUnmapped(qobject_cast<QWaylandSurface *>(sender()));
-}
-
-void LipstickCompositor::surfaceSizeChanged()
-{
-    QWaylandSurface *surface = qobject_cast<QWaylandSurface *>(sender());
-
-    LipstickCompositorWindow *window = surfaceWindow(surface);
-    if (window)
-        window->setSize(surface->size());
 }
 
 void LipstickCompositor::surfaceTitleChanged()

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -223,7 +223,6 @@ signals:
 private slots:
     void surfaceMapped();
     void surfaceUnmapped();
-    void surfaceSizeChanged();
     void surfaceTitleChanged();
     void surfaceRaised();
     void surfaceLowered();

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -274,7 +274,7 @@ bool LipstickCompositorWindow::eventFilter(QObject *obj, QEvent *event)
             // handling is maintained.
             if (te->touchPointStates() & (Qt::TouchPointPressed | Qt::TouchPointReleased))
                 return false;
-            handleTouchEvent(static_cast<QTouchEvent *>(event));
+            handleTouchEvent(static_cast<QTouchEvent *>(event), true);
             return true;
         }
         case QEvent::TouchEnd: // Intentional fall through...
@@ -405,7 +405,7 @@ void LipstickCompositorWindow::wheelEvent(QWheelEvent *event)
 void LipstickCompositorWindow::touchEvent(QTouchEvent *event)
 {
     if (touchEventsEnabled() && surface()) {
-        handleTouchEvent(event);
+        handleTouchEvent(event, false);
 
         static bool lipstick_touch_interception = qEnvironmentVariableIsEmpty("LIPSTICK_NO_TOUCH_INTERCEPTION");
         if (lipstick_touch_interception && event->type() == QEvent::TouchBegin) {
@@ -420,7 +420,7 @@ void LipstickCompositorWindow::touchEvent(QTouchEvent *event)
     }
 }
 
-void LipstickCompositorWindow::handleTouchEvent(QTouchEvent *event)
+void LipstickCompositorWindow::handleTouchEvent(QTouchEvent *event, bool intercepted)
 {
     QList<QTouchEvent::TouchPoint> points = event->touchPoints();
 
@@ -431,6 +431,7 @@ void LipstickCompositorWindow::handleTouchEvent(QTouchEvent *event)
     }
 
     if (event->touchPointStates() & Qt::TouchPointPressed) {
+        Q_ASSERT(!intercepted);
         foreach (const QTouchEvent::TouchPoint &p, points) {
             if ((m_mouseRegionValid && !m_mouseRegion.contains(p.pos().toPoint()))
                     || !m_surface->inputRegionContains(p.pos().toPoint())) {
@@ -445,15 +446,35 @@ void LipstickCompositorWindow::handleTouchEvent(QTouchEvent *event)
 
     if (inputDevice->mouseFocus() != this) {
         QPoint pointPos;
-        if (!points.isEmpty())
-            pointPos = points.at(0).pos().toPoint();
+        if (!points.isEmpty()) {
+            QPointF p = points.at(0).pos();
+            if (intercepted) {
+                pointPos = mapFromScene(p).toPoint();
+            } else {
+                pointPos = p.toPoint();
+            }
+        }
         inputDevice->setMouseFocus(this, pointPos, pointPos);
 
         if (m_focusOnTouch && inputDevice->keyboardFocus() != m_surface) {
             takeFocus();
         }
     }
-    inputDevice->sendFullTouchEvent(event);
+
+    if (event->type() == QEvent::TouchCancel) {
+        inputDevice->sendTouchCancelEvent();
+        return;
+    }
+
+    foreach (const QTouchEvent::TouchPoint &tp, points) {
+        QPointF p = tp.pos();
+        if (intercepted) {
+            p = mapFromScene(p);
+        }
+        inputDevice->sendTouchPointEvent(tp.id(), p.x(), p.y(), tp.state());
+    }
+
+    inputDevice->sendTouchFrameEvent();
 }
 
 void LipstickCompositorWindow::handleTouchCancel()

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -16,6 +16,8 @@
 #include <QCoreApplication>
 #include <QTimer>
 
+#include <QSGSimpleTextureNode>
+
 #include <QtCompositorVersion>
 #include <QWaylandCompositor>
 #include <QWaylandInputDevice>
@@ -26,6 +28,7 @@
 
 #include "lipstickcompositor.h"
 #include "lipstickcompositorwindow.h"
+#include "lipsticksurfaceinterface.h"
 
 LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &category,
                                                    QWaylandQuickSurface *surface, QQuickItem *parent)
@@ -331,6 +334,18 @@ void LipstickCompositorWindow::itemChange(ItemChange change, const ItemChangeDat
     QWaylandSurfaceItem::itemChange(change, data);
 }
 
+QSGNode *LipstickCompositorWindow::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *data)
+{
+    QSGNode *qsgNode = QWaylandSurfaceItem::updatePaintNode(oldNode, data);
+    if (!qsgNode || !m_sourceRect.isValid())
+        return qsgNode;
+
+    QSGSimpleTextureNode *node = static_cast<QSGSimpleTextureNode *>(qsgNode);
+    node->setSourceRect(m_sourceRect);
+
+    return node;
+}
+
 bool LipstickCompositorWindow::event(QEvent *e)
 {
     bool rv = QWaylandSurfaceItem::event(e);
@@ -540,7 +555,40 @@ void LipstickCompositorWindow::configure()
     if (op.m_resizeAcked)
         emit resizeAcked();
 
+    LipstickGetViewportOp vp;
+    surface()->sendInterfaceOp(vp);
+    m_sourceRect = vp.sourceRect();
+
+    if (vp.destSize().isValid()) {
+        setSize(vp.destSize());
+    } else if (m_sourceRect.isValid()) {
+        setSize(m_sourceRect.size());
+    } else if (surface()) {
+        setSize(surface()->size());
+    }
+
     emit committed();
+}
+
+qreal LipstickCompositorWindow::bufferScale() const
+{
+    return m_bufferScale;
+}
+
+void LipstickCompositorWindow::setBufferScale(qreal scale)
+{
+    if (m_bufferScale == scale)
+        return;
+
+    m_bufferScale = scale;
+
+    QWaylandSurface *m_surface = surface();
+    if (m_surface) {
+        LipstickBufferScaleOp op(scale);
+        surface()->sendInterfaceOp(op);
+    }
+
+    emit bufferScaleChanged();
 }
 
 QRect LipstickCompositorWindow::popupArea() const

--- a/src/compositor/lipstickcompositorwindow.cpp
+++ b/src/compositor/lipstickcompositorwindow.cpp
@@ -41,6 +41,7 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
     , m_interceptingTouch(false)
     , m_mapped(false)
     , m_focusOnTouch(false)
+    , m_isXdg(false)
 {
     setFlags(QQuickItem::ItemIsFocusScope | flags());
     refreshMouseRegion();
@@ -58,11 +59,14 @@ LipstickCompositorWindow::LipstickCompositorWindow(int windowId, const QString &
         m_processId = surface->client()->processId();
 
         m_isAlien = surface->property("alienSurface").toBool();
+        m_isXdg = surface->property("xdgSurface").toBool();
+
+        configure();
 
         connect(surface, &QWaylandSurface::clientDestroyedSurface, this, &LipstickCompositorWindow::closed);
 
         connect(surface, &QWaylandSurface::titleChanged, this, &LipstickCompositorWindow::titleChanged);
-        connect(surface, &QWaylandSurface::configure, this, &LipstickCompositorWindow::committed);
+        connect(surface, &QWaylandSurface::configure, this, &LipstickCompositorWindow::configure);
     }
 
     updatePolicyApplicationId();
@@ -133,6 +137,11 @@ int LipstickCompositorWindow::windowId() const
 bool LipstickCompositorWindow::isAlien() const
 {
     return m_isAlien;
+}
+
+bool LipstickCompositorWindow::isXdg() const
+{
+    return m_isXdg;
 }
 
 qint64 LipstickCompositorWindow::processId() const
@@ -500,4 +509,36 @@ void LipstickCompositorWindow::resize(const QSize &size)
         surface()->requestSize(size);
         emit resized();
     }
+}
+
+void LipstickCompositorWindow::configure()
+{
+    LipstickGetShellStateOp op;
+    surface()->sendInterfaceOp(op);
+
+    if (op.m_resizeAcked)
+        emit resizeAcked();
+
+    emit committed();
+}
+
+QRect LipstickCompositorWindow::popupArea() const
+{
+    return m_popupArea;
+}
+
+void LipstickCompositorWindow::setPopupArea(const QRect &bounds)
+{
+    if (m_popupArea == bounds)
+        return;
+
+    m_popupArea = bounds;
+
+    QWaylandSurface *m_surface = surface();
+    if (m_surface) {
+        LipstickSetPopupAreaOp op(bounds);
+        surface()->sendInterfaceOp(op);
+    }
+
+    emit popupAreaChanged();
 }

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -114,7 +114,7 @@ private:
     void tryRemove();
     void refreshMouseRegion();
     void refreshGrabbedKeys();
-    void handleTouchEvent(QTouchEvent *e);
+    void handleTouchEvent(QTouchEvent *e, bool intercepted);
 
     void updatePolicyApplicationId();
 

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -39,6 +39,8 @@ class LIPSTICK_EXPORT LipstickCompositorWindow : public QWaylandSurfaceItem
 
     Q_PROPERTY(QRect mouseRegionBounds READ mouseRegionBounds NOTIFY mouseRegionBoundsChanged)
     Q_PROPERTY(bool focusOnTouch READ focusOnTouch WRITE setFocusOnTouch NOTIFY focusOnTouchChanged)
+    Q_PROPERTY(QRect popupArea READ popupArea WRITE setPopupArea NOTIFY popupAreaChanged)
+    Q_PROPERTY(bool isXdg READ isXdg CONSTANT)
 
 public:
     LipstickCompositorWindow(int windowId, const QString &, QWaylandQuickSurface *surface, QQuickItem *parent = 0);
@@ -59,6 +61,7 @@ public:
     virtual bool isInProcess() const;
 
     bool isAlien() const;
+    bool isXdg() const;
 
     QRect mouseRegionBounds() const;
 
@@ -70,6 +73,9 @@ public:
     void setFocusOnTouch(bool focusOnTouch);
 
     Q_INVOKABLE void resize(const QSize &size);
+
+    QRect popupArea() const;
+    void setPopupArea(const QRect &bounds);
 
 protected:
     void itemChange(ItemChange change, const ItemChangeData &data);
@@ -90,10 +96,13 @@ signals:
     void focusOnTouchChanged();
     void resized();
     void closed();
+    void resizeAcked();
+    void popupAreaChanged();
 
 private slots:
     void handleTouchCancel();
     void killProcess();
+    void configure();
 
 private:
     friend class LipstickCompositor;
@@ -129,6 +138,8 @@ private:
         QList<int> keys;
     } m_pressedGrabbedKeys;
     QVector<QQuickItem *> m_refs;
+    QRect m_popupArea;
+    bool m_isXdg;
 };
 
 #endif // LIPSTICKCOMPOSITORWINDOW_H

--- a/src/compositor/lipstickcompositorwindow.h
+++ b/src/compositor/lipstickcompositorwindow.h
@@ -39,6 +39,7 @@ class LIPSTICK_EXPORT LipstickCompositorWindow : public QWaylandSurfaceItem
 
     Q_PROPERTY(QRect mouseRegionBounds READ mouseRegionBounds NOTIFY mouseRegionBoundsChanged)
     Q_PROPERTY(bool focusOnTouch READ focusOnTouch WRITE setFocusOnTouch NOTIFY focusOnTouchChanged)
+    Q_PROPERTY(double bufferScale READ bufferScale WRITE setBufferScale NOTIFY bufferScaleChanged)
     Q_PROPERTY(QRect popupArea READ popupArea WRITE setPopupArea NOTIFY popupAreaChanged)
     Q_PROPERTY(bool isXdg READ isXdg CONSTANT)
 
@@ -74,11 +75,15 @@ public:
 
     Q_INVOKABLE void resize(const QSize &size);
 
+    qreal bufferScale() const;
+    void setBufferScale(qreal scale);
+
     QRect popupArea() const;
     void setPopupArea(const QRect &bounds);
 
 protected:
     void itemChange(ItemChange change, const ItemChangeData &data);
+    QSGNode *updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *data);
 
     virtual bool event(QEvent *);
     virtual void mousePressEvent(QMouseEvent *event);
@@ -97,6 +102,7 @@ signals:
     void resized();
     void closed();
     void resizeAcked();
+    void bufferScaleChanged();
     void popupAreaChanged();
 
 private slots:
@@ -138,6 +144,8 @@ private:
         QList<int> keys;
     } m_pressedGrabbedKeys;
     QVector<QQuickItem *> m_refs;
+    QRectF m_sourceRect;
+    qreal m_bufferScale;
     QRect m_popupArea;
     bool m_isXdg;
 };

--- a/src/compositor/lipstickfractionalscale.cpp
+++ b/src/compositor/lipstickfractionalscale.cpp
@@ -1,0 +1,99 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include "lipsticksurfaceinterface.h"
+#include "lipstickfractionalscale.h"
+
+FractionalScaleGlobal::FractionalScaleGlobal(QObject *parent)
+    : QObject(parent)
+{
+}
+
+const wl_interface *FractionalScaleGlobal::interface() const
+{
+    return &wp_fractional_scale_manager_v1_interface;
+}
+
+void FractionalScaleGlobal::bind(wl_client *client, uint32_t version, uint32_t id)
+{
+    new FractionalScaleManager(client, version, id, this);
+}
+
+FractionalScaleManager::FractionalScaleManager(wl_client *client, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QtWaylandServer::wp_fractional_scale_manager_v1(client, id, version)
+{
+}
+
+FractionalScaleManager::~FractionalScaleManager()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+void FractionalScaleManager::wp_fractional_scale_manager_v1_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void FractionalScaleManager::wp_fractional_scale_manager_v1_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void FractionalScaleManager::wp_fractional_scale_manager_v1_get_fractional_scale(Resource *resource, uint32_t id, ::wl_resource *surface)
+{
+    Q_UNUSED(resource)
+
+    QWaylandSurface *surf = QWaylandSurface::fromResource(surface);
+    new FractionalScale(surf, wl_resource_get_version(resource->handle), id, this);
+}
+
+FractionalScale::FractionalScale(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QWaylandSurfaceInterface(surface)
+    , QtWaylandServer::wp_fractional_scale_v1(surface->client()->client(), id, version)
+{
+}
+
+FractionalScale::~FractionalScale()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+bool FractionalScale::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+    case LipstickBufferScaleOp::Type:
+        send_preferred_scale(static_cast<LipstickBufferScaleOp *>(op)->scale() * 120);
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+void FractionalScale::wp_fractional_scale_v1_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void FractionalScale::wp_fractional_scale_v1_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}

--- a/src/compositor/lipstickfractionalscale.h
+++ b/src/compositor/lipstickfractionalscale.h
@@ -1,0 +1,63 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef LIPSTICKFRACTIONALSCALE_H
+#define LIPSTICKFRACTIONALSCALE_H
+
+#include <QObject>
+#include <QtCompositor/QWaylandGlobalInterface>
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-fractional-scale-v1.h"
+
+class QWaylandSurface;
+
+class FractionalScaleGlobal : public QObject, public QWaylandGlobalInterface
+{
+public:
+    explicit FractionalScaleGlobal(QObject *parent = nullptr);
+
+    const wl_interface *interface() const override;
+    void bind(wl_client *client, uint32_t version, uint32_t id) override;
+};
+
+class FractionalScaleManager : public QObject, public QtWaylandServer::wp_fractional_scale_manager_v1
+{
+public:
+    FractionalScaleManager(wl_client *client, uint32_t version, uint32_t id, QObject *parent);
+    ~FractionalScaleManager();
+
+protected:
+    void wp_fractional_scale_manager_v1_destroy_resource(Resource *resource) override;
+    void wp_fractional_scale_manager_v1_destroy(Resource *resource) override;
+    void wp_fractional_scale_manager_v1_get_fractional_scale(Resource *resource, uint32_t id, ::wl_resource *surface) override;
+};
+
+class FractionalScale
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::wp_fractional_scale_v1
+{
+public:
+    FractionalScale(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent);
+    ~FractionalScale();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) override;
+
+    void wp_fractional_scale_v1_destroy_resource(Resource *resource) override;
+    void wp_fractional_scale_v1_destroy(Resource *resource) override;
+};
+
+#endif

--- a/src/compositor/lipsticksurfaceinterface.cpp
+++ b/src/compositor/lipsticksurfaceinterface.cpp
@@ -31,3 +31,14 @@ LipstickGetShellStateOp::LipstickGetShellStateOp()
     , m_resizeAcked(false)
 {
 }
+
+LipstickGetViewportOp::LipstickGetViewportOp()
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+{
+}
+
+LipstickBufferScaleOp::LipstickBufferScaleOp(qreal scale)
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+    , m_scale(scale)
+{
+}

--- a/src/compositor/lipsticksurfaceinterface.cpp
+++ b/src/compositor/lipsticksurfaceinterface.cpp
@@ -19,3 +19,15 @@ LipstickOomScoreOp::LipstickOomScoreOp(int score)
     , m_score(score)
 {
 }
+
+LipstickSetPopupAreaOp::LipstickSetPopupAreaOp(const QRect &bounds)
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+    , m_bounds(bounds)
+{
+}
+
+LipstickGetShellStateOp::LipstickGetShellStateOp()
+    : QWaylandSurfaceOp((QWaylandSurfaceOp::Type)Type)
+    , m_resizeAcked(false)
+{
+}

--- a/src/compositor/lipsticksurfaceinterface.h
+++ b/src/compositor/lipsticksurfaceinterface.h
@@ -52,4 +52,32 @@ public:
     bool m_resizeAcked : 1;
 };
 
+class LipstickGetViewportOp : public QWaylandSurfaceOp
+{
+public:
+    enum { Type = QWaylandSurfaceOp::UserType + 4 };
+    LipstickGetViewportOp();
+
+    const QRectF &sourceRect() const { return m_sourceRect; }
+    const QSize &destSize() const { return m_destSize; }
+
+private:
+    QRectF m_sourceRect;
+    QSize m_destSize;
+
+    friend class LipstickViewport;
+};
+
+class LipstickBufferScaleOp : public QWaylandSurfaceOp
+{
+public:
+    enum { Type = QWaylandSurfaceOp::UserType + 5 };
+    LipstickBufferScaleOp(qreal scale);
+
+    qreal scale() const { return m_scale; }
+
+private:
+    qreal m_scale;
+};
+
 #endif

--- a/src/compositor/lipsticksurfaceinterface.h
+++ b/src/compositor/lipsticksurfaceinterface.h
@@ -31,4 +31,25 @@ private:
     int m_score;
 };
 
+class LipstickSetPopupAreaOp : public QWaylandSurfaceOp
+{
+public:
+    enum { Type = QWaylandSurfaceOp::UserType + 2 };
+    LipstickSetPopupAreaOp(const QRect &bounds);
+
+    const QRect &bounds() const { return m_bounds; }
+
+private:
+    QRect m_bounds;
+};
+
+class LipstickGetShellStateOp : public QWaylandSurfaceOp
+{
+public:
+    enum { Type = QWaylandSurfaceOp::UserType + 3 };
+    LipstickGetShellStateOp();
+
+    bool m_resizeAcked : 1;
+};
+
 #endif

--- a/src/compositor/lipstickviewporter.cpp
+++ b/src/compositor/lipstickviewporter.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include "lipsticksurfaceinterface.h"
+#include "lipstickviewporter.h"
+
+ViewporterGlobal::ViewporterGlobal(QObject *parent)
+    : QObject(parent)
+{
+}
+
+const wl_interface *ViewporterGlobal::interface() const
+{
+    return &wp_viewporter_interface;
+}
+
+void ViewporterGlobal::bind(wl_client *client, uint32_t version, uint32_t id)
+{
+    new LipstickViewporter(client, version, id, this);
+}
+
+LipstickViewporter::LipstickViewporter(wl_client *client, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QtWaylandServer::wp_viewporter(client, id, version)
+{
+}
+
+LipstickViewporter::~LipstickViewporter()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+void LipstickViewporter::wp_viewporter_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void LipstickViewporter::wp_viewporter_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void LipstickViewporter::wp_viewporter_get_viewport(Resource *resource, uint32_t id, ::wl_resource *surface)
+{
+    Q_UNUSED(resource)
+
+    QWaylandSurface *surf = QWaylandSurface::fromResource(surface);
+    new LipstickViewport(surf, wl_resource_get_version(resource->handle), id, this);
+}
+
+LipstickViewport::LipstickViewport(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QWaylandSurfaceInterface(surface)
+    , QtWaylandServer::wp_viewport(surface->client()->client(), id, version)
+{
+}
+
+LipstickViewport::~LipstickViewport()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+bool LipstickViewport::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+    case LipstickGetViewportOp::Type: {
+        LipstickGetViewportOp *vp = static_cast<LipstickGetViewportOp *>(op);
+        vp->m_sourceRect = m_sourceRect;
+        vp->m_destSize = m_destSize;
+        return true;
+    }
+    default:
+        break;
+    }
+    return false;
+}
+
+void LipstickViewport::wp_viewport_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void LipstickViewport::wp_viewport_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void LipstickViewport::wp_viewport_set_source(Resource *resource, wl_fixed_t x, wl_fixed_t y, wl_fixed_t width, wl_fixed_t height)
+{
+    Q_UNUSED(resource)
+    m_sourceRect.setRect(wl_fixed_to_double(x), wl_fixed_to_double(y),
+                         wl_fixed_to_double(width), wl_fixed_to_double(height));
+}
+
+void LipstickViewport::wp_viewport_set_destination(Resource *resource, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource)
+    m_destSize = QSize(width, height);
+}

--- a/src/compositor/lipstickviewporter.h
+++ b/src/compositor/lipstickviewporter.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef LIPSTICKVIEWPORTER_H
+#define LIPSTICKVIEWPORTER_H
+
+#include <QObject>
+#include <QRect>
+#include <QtCompositor/QWaylandGlobalInterface>
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-viewporter.h"
+
+class QWaylandSurface;
+
+class ViewporterGlobal : public QObject, public QWaylandGlobalInterface
+{
+public:
+    explicit ViewporterGlobal(QObject *parent = nullptr);
+
+    const wl_interface *interface() const override;
+    void bind(wl_client *client, uint32_t version, uint32_t id) override;
+};
+
+class LipstickViewporter : public QObject, public QtWaylandServer::wp_viewporter
+{
+public:
+    LipstickViewporter(wl_client *client, uint32_t version, uint32_t id, QObject *parent);
+    ~LipstickViewporter();
+
+protected:
+    void wp_viewporter_destroy_resource(Resource *resource) override;
+    void wp_viewporter_destroy(Resource *resource) override;
+    void wp_viewporter_get_viewport(Resource *resource, uint32_t id, ::wl_resource *surface) override;
+};
+
+class LipstickViewport
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::wp_viewport
+{
+public:
+    LipstickViewport(QWaylandSurface *surface, uint32_t version, uint32_t id, QObject *parent);
+    ~LipstickViewport();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) override;
+
+    void wp_viewport_destroy_resource(Resource *resource) override;
+    void wp_viewport_destroy(Resource *resource) override;
+    void wp_viewport_set_source(Resource *resource, wl_fixed_t x, wl_fixed_t y, wl_fixed_t width, wl_fixed_t height) override;
+    void wp_viewport_set_destination(Resource *resource, int32_t width, int32_t height) override;
+
+private:
+    QRectF m_sourceRect;
+    QSize m_destSize;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgpopup.cpp
+++ b/src/compositor/xdgshell/xdgpopup.cpp
@@ -1,0 +1,111 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositorVersion>
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include <private/qwlsurface_p.h>
+
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+#include "xdgpopup.h"
+
+XdgPopup::XdgPopup(XdgSurface *xdgSurface, const QRect &rect, uint32_t version, uint32_t id)
+    : QObject(xdgSurface)
+    , QWaylandSurfaceInterface(xdgSurface->surface())
+    , QtWaylandServer::xdg_popup(surface()->client()->client(), id, version)
+    , m_xdgSurface(xdgSurface)
+    , m_rect(rect)
+{
+    setSurfaceType(QWaylandSurface::Popup);
+
+    XdgSurface *popupParent = xdgSurface->popupParent();
+    surface()->handle()->setTransientParent(popupParent->surface()->handle());
+    updateOffset();
+    sendConfigure();
+
+    connect(popupParent, &XdgSurface::geometryChanged, this, &XdgPopup::updateOffset);
+    connect(xdgSurface, &XdgSurface::geometryChanged, this, &XdgPopup::updateOffset);
+    connect(surface(), &QWaylandSurface::configure, this, &XdgPopup::configure);
+}
+
+XdgPopup::~XdgPopup()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+    surface()->setMapped(false);
+    m_xdgSurface->roleDestroyed();
+}
+
+bool XdgPopup::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+    case QWaylandSurfaceOp::Close:
+        send_popup_done();
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+void XdgPopup::xdg_popup_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void XdgPopup::xdg_popup_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgPopup::xdg_popup_reposition(Resource *resource, ::wl_resource *positioner, uint32_t token)
+{
+    Q_UNUSED(resource)
+
+    m_rect = XdgPositioner::fromResource(positioner)->toRect(m_xdgSurface->popupParent());
+    updateOffset();
+    send_repositioned(token);
+    sendConfigure();
+}
+
+void XdgPopup::configure(bool hasBuffer)
+{
+    surface()->setMapped(hasBuffer);
+}
+
+void XdgPopup::updateOffset()
+{
+    const QRect &geometry = m_xdgSurface->geometry();
+    const QRect &parentGeometry = m_xdgSurface->popupParent()->geometry();
+
+    int x = parentGeometry.left() + m_rect.left() - geometry.left();
+    int y = parentGeometry.top() + m_rect.top() - geometry.top();
+
+    bool mapped = surface()->isMapped();
+    surface()->setMapped(false);
+
+    surface()->handle()->setTransientOffset(x, y);
+
+    surface()->setMapped(mapped);
+}
+
+void XdgPopup::sendConfigure()
+{
+    send_configure(m_rect.left(), m_rect.top(), m_rect.width(), m_rect.height());
+    m_xdgSurface->sendConfigure();
+}

--- a/src/compositor/xdgshell/xdgpopup.h
+++ b/src/compositor/xdgshell/xdgpopup.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGPOPUP_H
+#define XDGPOPUP_H
+
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgSurface;
+
+class XdgPopup
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::xdg_popup
+{
+public:
+    XdgPopup(XdgSurface *xdgSurface, const QRect &rect, uint32_t version, uint32_t id);
+    ~XdgPopup();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) override;
+
+    void xdg_popup_destroy_resource(Resource *resource) override;
+    void xdg_popup_destroy(Resource *resource) override;
+    void xdg_popup_reposition(Resource *resource, ::wl_resource *positioner, uint32_t token) override;
+
+private:
+    void updateOffset();
+    void configure(bool hasBuffer);
+    void sendConfigure();
+
+    XdgSurface *m_xdgSurface;
+    QRect m_rect;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgpositioner.cpp
+++ b/src/compositor/xdgshell/xdgpositioner.cpp
@@ -1,0 +1,273 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include "lipstickcompositor.h"
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+#include "xdgtoplevel.h"
+
+namespace {
+
+Qt::Edges toEdges(uint32_t anchor)
+{
+    Qt::Edges edges = 0;
+
+    if (anchor == XDG_POSITIONER_ANCHOR_TOP
+        || anchor == XDG_POSITIONER_ANCHOR_TOP_LEFT
+        || anchor == XDG_POSITIONER_ANCHOR_TOP_RIGHT) {
+        edges |= Qt::TopEdge;
+    }
+
+    if (anchor == XDG_POSITIONER_ANCHOR_BOTTOM
+        || anchor == XDG_POSITIONER_ANCHOR_BOTTOM_LEFT
+        || anchor == XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT) {
+        edges |= Qt::BottomEdge;
+    }
+
+    if (anchor == XDG_POSITIONER_ANCHOR_LEFT
+        || anchor == XDG_POSITIONER_ANCHOR_TOP_LEFT
+        || anchor == XDG_POSITIONER_ANCHOR_BOTTOM_LEFT) {
+        edges |= Qt::LeftEdge;
+    }
+
+    if (anchor == XDG_POSITIONER_ANCHOR_RIGHT
+        || anchor == XDG_POSITIONER_ANCHOR_TOP_RIGHT
+        || anchor == XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT) {
+        edges |= Qt::RightEdge;
+    }
+
+    return edges;
+}
+
+Qt::Edges flipEdges(Qt::Edges edges, Qt::Orientations flip)
+{
+    Qt::Edges transformed = 0;
+
+    if (flip & Qt::Vertical) {
+        if (edges & Qt::TopEdge)
+            transformed |= Qt::BottomEdge;
+        if (edges & Qt::BottomEdge)
+            transformed |= Qt::TopEdge;
+    } else {
+        transformed |= edges & (Qt::TopEdge | Qt::BottomEdge);
+    }
+
+    if (flip & Qt::Horizontal) {
+        if (edges & Qt::LeftEdge)
+            transformed |= Qt::RightEdge;
+        if (edges & Qt::RightEdge)
+            transformed |= Qt::LeftEdge;
+    } else {
+        transformed |= edges & (Qt::LeftEdge | Qt::RightEdge);
+    }
+
+    return transformed;
+}
+
+} /* namespace */
+
+XdgPositioner::XdgPositioner(XdgShell *mgr, wl_client *client, uint32_t version, uint32_t id)
+    : QObject(mgr)
+    , QtWaylandServer::xdg_positioner(client, id, version)
+    , m_anchor(0)
+    , m_gravity(0)
+    , m_adjustment(XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_NONE)
+{
+}
+
+XdgPositioner::~XdgPositioner()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+XdgPositioner *XdgPositioner::fromResource(::wl_resource *resource)
+{
+    return static_cast<XdgPositioner *>(Resource::fromResource(resource)->xdg_positioner_object);
+}
+
+QRect XdgPositioner::toRect(const XdgSurface *surface) const
+{
+    if (m_size.isNull() || !m_anchorRect.isValid())
+        return QRect();
+
+    QRect bounds = surface->popupArea();
+
+    uint32_t adjustment = m_adjustment;
+    Qt::Edges anchor, gravity;
+    Qt::Orientations flip = 0;
+
+    QRect rect;
+
+    for (;;) {
+        int x = m_offset.x(), y = m_offset.y();
+
+        anchor = flipEdges(m_anchor, flip);
+        gravity = flipEdges(m_gravity, flip);
+
+        if (anchor & Qt::TopEdge) {
+            y += m_anchorRect.top();
+        } else if (anchor & Qt::BottomEdge) {
+            y += m_anchorRect.bottom() + 1;
+        } else {
+            y += m_anchorRect.top() + m_anchorRect.height() / 2;
+        }
+
+        if (anchor & Qt::LeftEdge) {
+            x += m_anchorRect.left();
+        } else if (anchor & Qt::RightEdge) {
+            x += m_anchorRect.right() + 1;
+        } else {
+            x += m_anchorRect.left() + m_anchorRect.width() / 2;
+        }
+
+        if (gravity & Qt::TopEdge) {
+            y -= m_size.height();
+        } else if (!(m_gravity & Qt::BottomEdge)) {
+            y -= m_size.height() / 2;
+        }
+
+        if (gravity & Qt::LeftEdge) {
+            x -= m_size.width();
+        } else if (!(gravity & Qt::RightEdge)) {
+            x -= m_size.width() / 2;
+        }
+
+        rect.setRect(x, y, m_size.width(), m_size.height());
+
+        // If the surface is contrained on a flippable axis, invert the anchor
+        // and gravity on that axis and try again. If this is the second
+        // attempt, revert to the original position.
+
+        if (rect.left() < bounds.left() || rect.right() > bounds.right()) {
+            if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X) {
+                adjustment &= ~XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X;
+                flip |= Qt::Horizontal;
+                continue;
+            } else if (flip & Qt::Horizontal) {
+                flip &= ~Qt::Horizontal;
+                continue;
+            }
+        }
+
+        if (rect.top() < bounds.top() || rect.bottom() > bounds.bottom()) {
+            if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y) {
+                adjustment &= ~XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y;
+                flip |= Qt::Vertical;
+                continue;
+            } else if (flip & Qt::Vertical) {
+                flip &= ~Qt::Vertical;
+                continue;
+            }
+        }
+
+        // If no flips are left to try, proceed with other options.
+        break;
+    }
+
+    // Try to move the surface so that at least one edge is unconstrained.
+    // Prefer movement in direction of gravity.
+
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X) {
+        if (gravity & Qt::LeftEdge) {
+            if (rect.left() < bounds.left()) {
+                rect.moveLeft(bounds.left());
+            }
+        }
+        if (rect.right() > bounds.right()) {
+            rect.moveRight(bounds.right());
+        }
+        if (!(gravity & Qt::LeftEdge)) {
+            if (rect.left() < bounds.left()) {
+                rect.moveLeft(bounds.left());
+            }
+        }
+    }
+
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y) {
+        if (gravity & Qt::TopEdge) {
+            if (rect.top() < bounds.top()) {
+                rect.moveTop(bounds.top());
+            }
+        }
+        if (rect.bottom() > bounds.bottom()) {
+            rect.moveBottom(bounds.bottom());
+        }
+        if (!(gravity & Qt::TopEdge)) {
+            if (rect.top() < bounds.top()) {
+                rect.moveTop(bounds.top());
+            }
+        }
+    }
+
+    // If allowed, resize the surface to make it unconstrained.
+    QRect resized = bounds & rect;
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_X) {
+        rect.setLeft(resized.left());
+        rect.setRight(resized.right());
+    }
+    if (adjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_Y) {
+        rect.setTop(resized.top());
+        rect.setBottom(resized.bottom());
+    }
+
+    return rect;
+}
+
+void XdgPositioner::xdg_positioner_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void XdgPositioner::xdg_positioner_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgPositioner::xdg_positioner_set_size(Resource *resource, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource)
+    m_size = QSize(width, height);
+}
+
+void XdgPositioner::xdg_positioner_set_anchor_rect(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource)
+    m_anchorRect.setRect(x, y, width, height);
+}
+
+void XdgPositioner::xdg_positioner_set_anchor(Resource *resource, uint32_t anchor)
+{
+    Q_UNUSED(resource)
+    m_anchor = toEdges(anchor);
+}
+
+void XdgPositioner::xdg_positioner_set_gravity(Resource *resource, uint32_t gravity)
+{
+    Q_UNUSED(resource)
+    m_gravity = toEdges(gravity);
+}
+
+void XdgPositioner::xdg_positioner_set_constraint_adjustment(Resource *resource, uint32_t adjustment)
+{
+    Q_UNUSED(resource)
+    m_adjustment = adjustment;
+}
+
+void XdgPositioner::xdg_positioner_set_offset(Resource *resource, int32_t x, int32_t y)
+{
+    Q_UNUSED(resource)
+    m_offset = QPoint(x, y);
+}

--- a/src/compositor/xdgshell/xdgpositioner.h
+++ b/src/compositor/xdgshell/xdgpositioner.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGPOSITIONER_H
+#define XDGPOSITIONER_H
+
+#include <QObject>
+#include <QRect>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgShell;
+class XdgSurface;
+
+class XdgPositioner : public QObject, public QtWaylandServer::xdg_positioner
+{
+public:
+    XdgPositioner(XdgShell *mgr, wl_client *client, uint32_t version, uint32_t id);
+    ~XdgPositioner();
+
+    static XdgPositioner *fromResource(::wl_resource *resource);
+
+    QRect toRect(const XdgSurface *surface) const;
+
+protected:
+    void xdg_positioner_destroy_resource(Resource *resource) override;
+    void xdg_positioner_destroy(Resource *resource) override;
+    void xdg_positioner_set_size(Resource *resource, int32_t width, int32_t height) override;
+    void xdg_positioner_set_anchor_rect(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height) override;
+    void xdg_positioner_set_anchor(Resource *resource, uint32_t anchor) override;
+    void xdg_positioner_set_gravity(Resource *resource, uint32_t gravity) override;
+    void xdg_positioner_set_constraint_adjustment(Resource *resource, uint32_t adjustment) override;
+    void xdg_positioner_set_offset(Resource *resource, int32_t x, int32_t y) override;
+
+private:
+    QSize m_size;
+    QRect m_anchorRect;
+    Qt::Edges m_anchor;
+    Qt::Edges m_gravity;
+    uint32_t m_adjustment;
+    QPoint m_offset;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgshell.cpp
+++ b/src/compositor/xdgshell/xdgshell.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandSurface>
+
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+
+XdgShellGlobal::XdgShellGlobal(QObject *parent)
+    : QObject(parent)
+{
+}
+
+const wl_interface *XdgShellGlobal::interface() const
+{
+    return &xdg_wm_base_interface;
+}
+
+void XdgShellGlobal::bind(wl_client *client, uint32_t version, uint32_t id)
+{
+    new XdgShell(client, version, id, this);
+}
+
+XdgShell::XdgShell(wl_client *client, uint32_t version, uint32_t id, QObject *parent)
+    : QObject(parent)
+    , QtWaylandServer::xdg_wm_base(client, id, version)
+{
+}
+
+XdgShell::~XdgShell()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+void XdgShell::ping(uint32_t serial, QWaylandSurface *surface)
+{
+    m_pings.insert(serial, surface);
+    send_ping(serial);
+}
+
+void XdgShell::xdg_wm_base_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void XdgShell::xdg_wm_base_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgShell::xdg_wm_base_create_positioner(Resource *resource, uint32_t id)
+{
+    new XdgPositioner(this, resource->client(), wl_resource_get_version(resource->handle), id);
+}
+
+void XdgShell::xdg_wm_base_get_xdg_surface(Resource *resource, uint32_t id, ::wl_resource *surface)
+{
+    QWaylandSurface *surf = QWaylandSurface::fromResource(surface);
+    new XdgSurface(this, surf, wl_resource_get_version(resource->handle), id);
+}
+
+void XdgShell::xdg_wm_base_pong(Resource *resource, uint32_t serial)
+{
+    Q_UNUSED(resource)
+
+    QWaylandSurface *surf = m_pings.value(serial);
+    if (surf)
+        surf->pong();
+}

--- a/src/compositor/xdgshell/xdgshell.h
+++ b/src/compositor/xdgshell/xdgshell.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGSHELL_H
+#define XDGSHELL_H
+
+#include <QObject>
+#include <QtCompositor/QWaylandGlobalInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgShellGlobal : public QObject, public QWaylandGlobalInterface
+{
+public:
+    explicit XdgShellGlobal(QObject *parent = nullptr);
+
+    const wl_interface *interface() const override;
+    void bind(wl_client *client, uint32_t version, uint32_t id) override;
+};
+
+class XdgShell : public QObject, public QtWaylandServer::xdg_wm_base
+{
+public:
+    XdgShell(wl_client *client, uint32_t version, uint32_t id, QObject *parent);
+    ~XdgShell();
+
+    void ping(uint32_t serial, QWaylandSurface *surface);
+
+protected:
+    void xdg_wm_base_destroy_resource(Resource *resource) override;
+    void xdg_wm_base_destroy(Resource *resource) override;
+    void xdg_wm_base_create_positioner(Resource *resource, uint32_t id) override;
+    void xdg_wm_base_get_xdg_surface(Resource *resource, uint32_t id, ::wl_resource *surface) override;
+    void xdg_wm_base_pong(Resource *resource, uint32_t serial) override;
+
+private:
+    QMap<uint32_t, QWaylandSurface *> m_pings;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgshell.pri
+++ b/src/compositor/xdgshell/xdgshell.pri
@@ -1,0 +1,21 @@
+INCLUDEPATH += $$PWD
+
+HEADERS += \
+    $$PWD/xdgshell.h \
+    $$PWD/xdgpositioner.h \
+    $$PWD/xdgsurface.h \
+    $$PWD/xdgtoplevel.h \
+    $$PWD/xdgpopup.h \
+
+SOURCES += \
+    $$PWD/xdgshell.cpp \
+    $$PWD/xdgpositioner.cpp \
+    $$PWD/xdgsurface.cpp \
+    $$PWD/xdgtoplevel.cpp \
+    $$PWD/xdgpopup.cpp \
+
+PROTOCOL_PATH = $$system($$pkgConfigExecutable() --variable=pkgdatadir wayland-protocols)
+
+WAYLANDSERVERSOURCES += $$PROTOCOL_PATH/stable/xdg-shell/xdg-shell.xml \
+
+QT += compositor

--- a/src/compositor/xdgshell/xdgsurface.cpp
+++ b/src/compositor/xdgshell/xdgsurface.cpp
@@ -1,0 +1,144 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandCompositor>
+#include <QtCompositor/QWaylandSurface>
+
+#include "lipsticksurfaceinterface.h"
+#include "xdgshell.h"
+#include "xdgpositioner.h"
+#include "xdgsurface.h"
+#include "xdgtoplevel.h"
+#include "xdgpopup.h"
+
+XdgSurface::XdgSurface(XdgShell *mgr, QWaylandSurface *surface, uint32_t version, uint32_t id)
+    : QObject(mgr)
+    , QWaylandSurfaceInterface(surface)
+    , QtWaylandServer::xdg_surface(surface->client()->client(), id, version)
+    , m_manager(mgr)
+    , m_popupParent(nullptr)
+    , m_toplevel(nullptr)
+    , m_serial(0)
+    , m_ackPending(false)
+{
+    connect(surface, &QWaylandSurface::configure, this, &XdgSurface::handleCommit);
+    surface->setProperty("xdgSurface", true);
+}
+
+XdgSurface::~XdgSurface()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+}
+
+QRect XdgSurface::popupArea() const
+{
+    if (m_toplevel) {
+        return m_toplevel->popupArea();
+    }
+
+    if (m_popupParent) {
+        return m_popupParent->popupArea().translated(-surface()->transientOffset().toPoint());
+    }
+
+    return QRect();
+}
+
+void XdgSurface::sendConfigure()
+{
+    m_serial = wl_display_next_serial(surface()->compositor()->waylandDisplay());
+    send_configure(m_serial);
+}
+
+void XdgSurface::roleDestroyed()
+{
+    setParent(m_manager);
+    m_popupParent = nullptr;
+    m_toplevel = nullptr;
+    m_geometry = QRect();
+    m_pendingGeometry = QRect();
+}
+
+bool XdgSurface::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+    case QWaylandSurfaceOp::Ping:
+        m_manager->ping(static_cast<QWaylandSurfacePingOp *>(op)->serial(), surface());
+        return true;
+    case LipstickGetShellStateOp::Type:
+        static_cast<LipstickGetShellStateOp *>(op)->m_resizeAcked = m_ackPending;
+        m_ackPending = false;
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+void XdgSurface::xdg_surface_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void XdgSurface::xdg_surface_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgSurface::xdg_surface_get_toplevel(Resource *resource, uint32_t id)
+{
+    if (m_popupParent || m_toplevel)
+        return;
+
+    m_toplevel = new XdgToplevel(this, wl_resource_get_version(resource->handle), id);
+}
+
+void XdgSurface::xdg_surface_get_popup(Resource *resource, uint32_t id, ::wl_resource *parent, ::wl_resource *positioner)
+{
+    Q_UNUSED(resource)
+
+    if (!parent || m_popupParent || m_toplevel)
+        return;
+
+    m_popupParent = static_cast<XdgSurface *>(Resource::fromResource(parent)->xdg_surface_object);
+    setParent(m_popupParent);
+
+    QRect pos = XdgPositioner::fromResource(positioner)->toRect(m_popupParent);
+    new XdgPopup(this, pos, wl_resource_get_version(resource->handle), id);
+}
+
+void XdgSurface::xdg_surface_set_window_geometry(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
+{
+    Q_UNUSED(resource)
+    m_pendingGeometry.setRect(x, y, width, height);
+}
+
+void XdgSurface::xdg_surface_ack_configure(Resource *resource, uint32_t serial)
+{
+    Q_UNUSED(resource)
+
+    if (serial == m_serial) {
+        m_serial = 0;
+        m_ackPending = true;
+    }
+}
+
+void XdgSurface::handleCommit()
+{
+    if (m_geometry != m_pendingGeometry) {
+        m_geometry = m_pendingGeometry;
+        emit geometryChanged();
+    }
+}

--- a/src/compositor/xdgshell/xdgsurface.h
+++ b/src/compositor/xdgshell/xdgsurface.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGSURFACE_H
+#define XDGSURFACE_H
+
+#include <QObject>
+#include <QRect>
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class QWaylandSurface;
+
+class XdgShell;
+class XdgToplevel;
+
+class XdgSurface
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::xdg_surface
+{
+    Q_OBJECT
+
+public:
+    XdgSurface(XdgShell *mgr, QWaylandSurface *surface, uint32_t version, uint32_t id);
+    ~XdgSurface();
+
+    uint32_t serial() const { return m_serial; }
+    XdgSurface *popupParent() const { return m_popupParent; }
+    const QRect &geometry() const { return m_geometry; }
+
+    QRect popupArea() const;
+
+    void sendConfigure();
+    void roleDestroyed();
+
+signals:
+    void geometryChanged();
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) override;
+
+    void xdg_surface_destroy_resource(Resource *resource) override;
+    void xdg_surface_destroy(Resource *resource) override;
+    void xdg_surface_get_toplevel(Resource *resource, uint32_t id) override;
+    void xdg_surface_get_popup(Resource *resource, uint32_t id, ::wl_resource *parent, ::wl_resource *positioner) override;
+    void xdg_surface_set_window_geometry(Resource *resource, int32_t x, int32_t y, int32_t width, int32_t height) override;
+    void xdg_surface_ack_configure(Resource *resource, uint32_t serial) override;
+
+private slots:
+    void handleCommit();
+
+private:
+    XdgShell *m_manager;
+    XdgSurface *m_popupParent;
+    XdgToplevel *m_toplevel;
+    QRect m_pendingGeometry;
+    QRect m_geometry;
+    uint32_t m_serial;
+    bool m_ackPending;
+};
+
+#endif

--- a/src/compositor/xdgshell/xdgtoplevel.cpp
+++ b/src/compositor/xdgshell/xdgtoplevel.cpp
@@ -1,0 +1,198 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#include <QtCompositorVersion>
+
+#include <QtCompositor/QWaylandClient>
+#include <QtCompositor/QWaylandSurface>
+
+#include <private/qwlsurface_p.h>
+
+#include "lipstickcompositor.h"
+#include "lipsticksurfaceinterface.h"
+#include "xdgshell.h"
+#include "xdgsurface.h"
+#include "xdgtoplevel.h"
+
+XdgToplevel::XdgToplevel(XdgSurface *xdgSurface, uint32_t version, uint32_t id)
+    : QObject(xdgSurface)
+    , QWaylandSurfaceInterface(xdgSurface->surface())
+    , QtWaylandServer::xdg_toplevel(surface()->client()->client(), id, version)
+    , m_xdgSurface(xdgSurface)
+    , m_parentToplevel(nullptr)
+    , m_hidden(false)
+    , m_coverized(false)
+{
+    setSurfaceType(QWaylandSurface::Toplevel);
+
+    LipstickCompositor *compositor = LipstickCompositor::instance();
+    m_size = QSize(compositor->width(), compositor->height());
+    sendConfigure();
+
+    connect(xdgSurface, &XdgSurface::geometryChanged, this, &XdgToplevel::geometryChanged);
+    connect(surface(), &QWaylandSurface::configure, this, &XdgToplevel::configure);
+}
+
+XdgToplevel::~XdgToplevel()
+{
+    wl_resource_set_implementation(resource()->handle, nullptr, nullptr, nullptr);
+    surface()->setMapped(false);
+    m_xdgSurface->roleDestroyed();
+}
+
+bool XdgToplevel::runOperation(QWaylandSurfaceOp *op)
+{
+    switch (op->type()) {
+    case QWaylandSurfaceOp::Close:
+        send_close();
+        return true;
+    case QWaylandSurfaceOp::SetVisibility: {
+        QWindow::Visibility v = static_cast<QWaylandSurfaceSetVisibilityOp *>(op)->visibility();
+        m_hidden = v == QWindow::Hidden;
+        m_coverized = v == QWindow::Minimized;
+        sendConfigure();
+        return true;
+    }
+    case QWaylandSurfaceOp::Resize:
+        m_size = static_cast<QWaylandSurfaceResizeOp *>(op)->size();
+        sendConfigure();
+        return true;
+    case LipstickSetPopupAreaOp::Type:
+        setPopupArea(static_cast<LipstickSetPopupAreaOp *>(op)->bounds());
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+void XdgToplevel::xdg_toplevel_destroy_resource(Resource *resource)
+{
+    Q_UNUSED(resource)
+    delete this;
+}
+
+void XdgToplevel::xdg_toplevel_destroy(Resource *resource)
+{
+    wl_resource_destroy(resource->handle);
+}
+
+void XdgToplevel::xdg_toplevel_set_parent(Resource *resource, ::wl_resource *parent)
+{
+    Q_UNUSED(resource)
+    setParentToplevel(parent
+        ? static_cast<XdgToplevel *>(Resource::fromResource(parent)->xdg_toplevel_object)
+        : nullptr);
+}
+
+void XdgToplevel::xdg_toplevel_set_title(Resource *resource, const QString &title)
+{
+    Q_UNUSED(resource)
+    setSurfaceTitle(title);
+}
+
+void XdgToplevel::xdg_toplevel_set_app_id(Resource *resource, const QString &appId)
+{
+    Q_UNUSED(resource)
+    setSurfaceClassName(appId);
+}
+
+void XdgToplevel::xdg_toplevel_set_minimized(Resource *resource)
+{
+    Q_UNUSED(resource)
+    emit surface()->lowerRequested();
+}
+
+void XdgToplevel::configure(bool hasBuffer)
+{
+    if (hasBuffer && m_xdgSurface->geometry().isNull()) {
+        m_size = surface()->size();
+    }
+    surface()->setMapped(hasBuffer);
+}
+
+void XdgToplevel::sendConfigure()
+{
+    QVector<uint32_t> states;
+    states << XDG_TOPLEVEL_STATE_MAXIMIZED;
+    if (!m_coverized && !m_hidden) {
+        states << XDG_TOPLEVEL_STATE_ACTIVATED;
+    }
+    QByteArray data = QByteArray::fromRawData((char *)states.data(), states.size() * sizeof(uint32_t));
+
+    send_configure(m_size.width(), m_size.height(), data);
+    m_xdgSurface->sendConfigure();
+}
+
+void XdgToplevel::geometryChanged()
+{
+    if (m_xdgSurface->geometry().isValid()) {
+        m_size = m_xdgSurface->geometry().size();
+    }
+}
+
+void XdgToplevel::parentPopupAreaChanged(const QRect &bounds)
+{
+    setPopupArea(bounds);
+    surface()->handle()->setTransientOffset(bounds.x(), bounds.y());
+    m_size = bounds.size();
+    sendConfigure();
+}
+
+void XdgToplevel::parentUnmapped()
+{
+    setParentToplevel(m_parentToplevel->m_parentToplevel);
+}
+
+void XdgToplevel::setPopupArea(const QRect &bounds)
+{
+    if (m_popupArea != bounds) {
+        m_popupArea = bounds;
+        emit popupAreaChanged(bounds);
+    }
+}
+
+void XdgToplevel::setParentToplevel(XdgToplevel *parent)
+{
+    if (m_parentToplevel == parent)
+        return;
+
+    if (m_parentToplevel) {
+        disconnect(m_parentToplevel, &XdgToplevel::popupAreaChanged,
+                   this, &XdgToplevel::parentPopupAreaChanged);
+        disconnect(m_parentToplevel->surface(), &QWaylandSurface::unmapped,
+                   this, &XdgToplevel::parentUnmapped);
+    }
+
+    m_parentToplevel = parent;
+
+    bool mapped = surface()->isMapped();
+    surface()->setMapped(false);
+
+    if (parent) {
+        parentPopupAreaChanged(parent->popupArea());
+
+        QWaylandSurface *parentSurface = parent->surface();
+        surface()->handle()->setTransientParent(parentSurface->handle());
+
+        connect(parent, &XdgToplevel::popupAreaChanged,
+                this, &XdgToplevel::parentPopupAreaChanged);
+        connect(parentSurface, &QWaylandSurface::unmapped,
+                this, &XdgToplevel::parentUnmapped);
+    } else {
+        surface()->handle()->setTransientParent(nullptr);
+    }
+
+    surface()->setMapped(mapped);
+}

--- a/src/compositor/xdgshell/xdgtoplevel.h
+++ b/src/compositor/xdgshell/xdgtoplevel.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+** This file is part of lipstick.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file LICENSE.LGPL included in the packaging
+** of this file.
+**
+****************************************************************************/
+
+#ifndef XDGTOPLEVEL_H
+#define XDGTOPLEVEL_H
+
+#include <QtCompositor/QWaylandSurfaceInterface>
+
+#include "qwayland-server-xdg-shell.h"
+
+class XdgSurface;
+
+class XdgToplevel
+    : public QObject
+    , public QWaylandSurfaceInterface
+    , public QtWaylandServer::xdg_toplevel
+{
+    Q_OBJECT
+
+public:
+    XdgToplevel(XdgSurface *xdgSurface, uint32_t version, uint32_t id);
+    ~XdgToplevel();
+
+    const QRect &popupArea() const { return m_popupArea; }
+
+signals:
+    void popupAreaChanged(const QRect &bounds);
+
+protected:
+    bool runOperation(QWaylandSurfaceOp *op) override;
+
+    void xdg_toplevel_destroy_resource(Resource *resource) override;
+    void xdg_toplevel_destroy(Resource *resource) override;
+    void xdg_toplevel_set_parent(Resource *resource, ::wl_resource *parent) override;
+    void xdg_toplevel_set_title(Resource *resource, const QString &title) override;
+    void xdg_toplevel_set_app_id(Resource *resource, const QString &appId) override;
+    void xdg_toplevel_set_minimized(Resource *resource) override;
+
+private slots:
+    void configure(bool hasBuffer);
+    void geometryChanged();
+    void parentPopupAreaChanged(const QRect &bounds);
+    void parentUnmapped();
+
+private:
+    void setPopupArea(const QRect &bounds);
+    void setParentToplevel(XdgToplevel *parent);
+    void sendConfigure();
+
+    XdgSurface *m_xdgSurface;
+    XdgToplevel *m_parentToplevel;
+    bool m_hidden;
+    bool m_coverized;
+    QSize m_size;
+    QRect m_popupArea;
+};
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -24,6 +24,7 @@ INCLUDEPATH += utilities touchscreen components xtools 3rdparty devicestate
 
 include(compositor/compositor.pri)
 include(compositor/alienmanager/alienmanager.pri)
+include(compositor/xdgshell/xdgshell.pri)
 
 PUBLICHEADERS += \
     utilities/qobjectlistmodel.h \

--- a/tests/stubs/lipstickcompositor_stub.h
+++ b/tests/stubs/lipstickcompositor_stub.h
@@ -56,7 +56,6 @@ public:
     virtual QWaylandSurface *surfaceForId(int) const;
     virtual void surfaceMapped();
     virtual void surfaceUnmapped();
-    virtual void surfaceSizeChanged();
     virtual void surfaceTitleChanged();
     virtual void surfaceRaised();
     virtual void surfaceLowered();
@@ -276,11 +275,6 @@ void LipstickCompositorStub::surfaceMapped()
 void LipstickCompositorStub::surfaceUnmapped()
 {
     stubMethodEntered("surfaceUnmapped");
-}
-
-void LipstickCompositorStub::surfaceSizeChanged()
-{
-    stubMethodEntered("surfaceSizeChanged");
 }
 
 void LipstickCompositorStub::surfaceTitleChanged()
@@ -565,11 +559,6 @@ void LipstickCompositor::surfaceMapped()
 void LipstickCompositor::surfaceUnmapped()
 {
     gLipstickCompositorStub->surfaceUnmapped();
-}
-
-void LipstickCompositor::surfaceSizeChanged()
-{
-    gLipstickCompositorStub->surfaceSizeChanged();
 }
 
 void LipstickCompositor::surfaceTitleChanged()


### PR DESCRIPTION
Changes compared to #68:
 - do not automatically change window size, let the QML side do that when needed
 - remove special handling of `scale` property, add new `bufferScale` property instead
 - treat toplevel windows with a parent as transient windows
 - add `isXdg` property
 - add `resizeAcked` signal that is emitted when all resize operations are complete
 - add `popupArea` property so that the window layout can be taken into account when constraining popups
 
One thing that's still missing is the keyboard focus handling for popups. At the moment popups will receive focus via focusOnTouch, but that should be disabled for popups that don't request a grab, and ideally popups that do request a grab should receive focus automatically.