### PR TITLE
[lipstick] Don't remove window twice

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -618,7 +618,6 @@ void LipstickCompositor::windowSwapped()
 void LipstickCompositor::windowDestroyed()
 {
     m_totalWindowCount--;
-    m_windows.remove(static_cast<LipstickCompositorWindow *>(sender())->windowId());
     emit ghostWindowCountChanged();
 }
 


### PR DESCRIPTION
It is a bit confusing that there are two overloaded windowDestroyed() methods in LipstickCompositor. One of them is called directly from the window destructor and takes a LipstickCompositorWindow as an argument. It already takes care of removing the window from m_windows.

The other one does not take any arguments and is set up as a handler for the destroyed() signal, which may be queued and arrive after the window is already gone if it was destroyed from the rendering thread. Do not try to remove the window from m_windows again here.