### PR TITLE
Set Wayland output plugin refresh rate. Fixes JB#64105

### DIFF
--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -200,8 +200,13 @@ void LipstickCompositor::componentComplete()
 {
     QScreen * const screen = QGuiApplication::primaryScreen();
 
-    m_output.setGeometry(QRect(QPoint(0, 0), screen->size()));
+    m_output.setPosition(QPoint(0, 0));
     m_output.setPhysicalSize(screen->physicalSize().toSize());
+
+    QWaylandOutput::Mode output_mode;
+    output_mode.size = screen->size();
+    output_mode.refreshRate = screen->refreshRate();
+    m_output.setMode(output_mode);
 }
 
 void LipstickCompositor::surfaceCreated(QWaylandSurface *surface)


### PR DESCRIPTION
QWaylandScreen defaults refresh rate to 60Hz, so tell it the actual refresh rate as reported by hardware composer. This fixes too fast animations on devices with higher refresh rate, since animation frame time calculations are based on said refresh rate.