### PR TITLE
Add checkSupported queries

### DIFF
--- a/src/compositor/compositor.pri
+++ b/src/compositor/compositor.pri
@@ -1,5 +1,4 @@
 system(qdbusxml2cpp compositor.xml -a lipstickcompositoradaptor -c LipstickCompositorAdaptor -l LipstickCompositor -i lipstickcompositor.h)
-system(qdbusxml2cpp fileservice.xml -a fileserviceadaptor -c FileServiceAdaptor)
 
 INCLUDEPATH += $$PWD
 

--- a/src/compositor/fileservice.xml
+++ b/src/compositor/fileservice.xml
@@ -1,6 +1,14 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
   <interface name="org.sailfishos.fileservice">
+    <method name="checkMimeSupported">
+      <arg name="mimeType" type="s" direction="in"/>
+      <arg name="supported" type="b" direction="out"/>
+    </method>
+    <method name="checkUrlSupported">
+      <arg name="url" type="s" direction="in"/>
+      <arg name="supported" type="b" direction="out"/>
+    </method>
     <method name="openUrl">
       <arg name="url" type="s" direction="in"/>
     </method>

--- a/src/compositor/fileserviceadaptor.cpp
+++ b/src/compositor/fileserviceadaptor.cpp
@@ -1,0 +1,36 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+****************************************************************************/
+
+#include "fileserviceadaptor.h"
+
+#include "lipstickcompositor.h"
+
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusMessage>
+
+FileServiceAdaptor::FileServiceAdaptor(LipstickCompositor *compositor)
+    : QDBusAbstractAdaptor(compositor)
+    , m_compositor(compositor)
+{
+    setAutoRelaySignals(true);
+}
+
+void FileServiceAdaptor::checkMimeSupported(const QString &mimeType, const QDBusMessage &message)
+{
+    message.setDelayedReply(true);
+    m_compositor->checkMimeSupported(mimeType, message, QDBusConnection::sessionBus());
+}
+
+void FileServiceAdaptor::checkUrlSupported(const QString &url, const QDBusMessage &message)
+{
+    message.setDelayedReply(true);
+    m_compositor->checkUrlSupported(url, message, QDBusConnection::sessionBus());
+}
+
+void FileServiceAdaptor::openUrl(const QString &url, const QDBusMessage &)
+{
+    m_compositor->openUrl(url);
+}

--- a/src/compositor/fileserviceadaptor.h
+++ b/src/compositor/fileserviceadaptor.h
@@ -1,0 +1,48 @@
+/***************************************************************************
+**
+** Copyright (c) 2026 Jolla Mobile Ltd
+**
+****************************************************************************/
+
+#ifndef FILESERVICEADAPTOR_H
+#define FILESERVICEADAPTOR_H
+
+#include <QtDBus/QDBusAbstractAdaptor>
+#include <QtDBus/QDBusMessage>
+#include <QtCore/QString>
+
+class LipstickCompositor;
+
+class FileServiceAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.sailfishos.fileservice")
+    Q_CLASSINFO("D-Bus Introspection", ""
+"  <interface name=\"org.sailfishos.fileservice\">\n"
+"    <method name=\"checkMimeSupported\">\n"
+"      <arg direction=\"in\" type=\"s\" name=\"mimeType\"/>\n"
+"      <arg direction=\"out\" type=\"b\" name=\"supported\"/>\n"
+"    </method>\n"
+"    <method name=\"checkUrlSupported\">\n"
+"      <arg direction=\"in\" type=\"s\" name=\"url\"/>\n"
+"      <arg direction=\"out\" type=\"b\" name=\"supported\"/>\n"
+"    </method>\n"
+"    <method name=\"openUrl\">\n"
+"      <arg direction=\"in\" type=\"s\" name=\"url\"/>\n"
+"    </method>\n"
+"  </interface>\n"
+        "")
+
+public:
+    explicit FileServiceAdaptor(LipstickCompositor *compositor);
+
+public slots:
+    Q_NOREPLY void checkMimeSupported(const QString &mimeType, const QDBusMessage &message);
+    Q_NOREPLY void checkUrlSupported(const QString &url, const QDBusMessage &message);
+    void openUrl(const QString &url, const QDBusMessage &message);
+
+private:
+    LipstickCompositor *m_compositor;
+};
+
+#endif

--- a/src/compositor/lipstickcompositor.cpp
+++ b/src/compositor/lipstickcompositor.cpp
@@ -18,7 +18,9 @@
 #include <QDesktopServices>
 #include <QtSensors/QOrientationSensor>
 #include <QClipboard>
+#include <QMetaMethod>
 #include <QMimeData>
+#include <QVariantList>
 #include <QtGui/qpa/qplatformnativeinterface.h>
 #include <QtGui/qpa/qplatformintegration.h>
 #include <qpa/qwindowsysteminterface.h>
@@ -48,6 +50,8 @@
 #include "logging.h"
 
 namespace {
+const int FileServiceRequestTimeout = 30 * 1000;
+
 bool debuggingCompositorHandover()
 {
     static int debugging = -1;
@@ -84,6 +88,7 @@ LipstickCompositor::LipstickCompositor()
     , m_keymap(0)
     , m_fakeRepaintTimerId(0)
     , m_queuedSetUpdatesEnabledCalls()
+    , m_nextFileServiceCallId(1)
     , m_mceNameOwner(new QMceNameOwner(this))
     , m_sessionActivationTries(0)
 {
@@ -239,6 +244,53 @@ bool LipstickCompositor::openUrl(const QUrl &url)
     openUrlRequested(url);
 
     return true;
+}
+
+void LipstickCompositor::checkMimeSupported(const QString &mimeType, const QDBusMessage &message,
+                                            const QDBusConnection &connection)
+{
+    if (!isSignalConnected(QMetaMethod::fromSignal(&LipstickCompositor::checkMimeSupportedRequested))) {
+        connection.send(message.createReply(QVariantList() << false));
+        return;
+    }
+
+    const uint requestId = m_nextFileServiceCallId++;
+    if (m_nextFileServiceCallId == 0)
+        m_nextFileServiceCallId = 1;
+
+    m_queuedFileServiceCalls.insert(requestId, QueuedFileServiceCall(connection, message));
+    QTimer::singleShot(FileServiceRequestTimeout, this, [this, requestId]() {
+        respondSupportCheck(requestId, false);
+    });
+    emit checkMimeSupportedRequested(requestId, mimeType);
+}
+
+void LipstickCompositor::checkUrlSupported(const QString &url, const QDBusMessage &message,
+                                           const QDBusConnection &connection)
+{
+    if (!isSignalConnected(QMetaMethod::fromSignal(&LipstickCompositor::checkUrlSupportedRequested))) {
+        connection.send(message.createReply(QVariantList() << false));
+        return;
+    }
+
+    const uint requestId = m_nextFileServiceCallId++;
+    if (m_nextFileServiceCallId == 0)
+        m_nextFileServiceCallId = 1;
+
+    m_queuedFileServiceCalls.insert(requestId, QueuedFileServiceCall(connection, message));
+    QTimer::singleShot(FileServiceRequestTimeout, this, [this, requestId]() {
+        respondSupportCheck(requestId, false);
+    });
+    emit checkUrlSupportedRequested(requestId, QUrl(url));
+}
+
+void LipstickCompositor::respondSupportCheck(uint requestId, bool supported)
+{
+    if (!m_queuedFileServiceCalls.contains(requestId))
+        return;
+
+    const QueuedFileServiceCall queued = m_queuedFileServiceCalls.take(requestId);
+    queued.m_connection.send(queued.m_message.createReply(QVariantList() << supported));
 }
 
 void LipstickCompositor::retainedSelectionReceived(QMimeData *mimeData)

--- a/src/compositor/lipstickcompositor.h
+++ b/src/compositor/lipstickcompositor.h
@@ -61,6 +61,23 @@ struct QueuedSetUpdatesEnabledCall
     bool m_enable;
 };
 
+struct QueuedFileServiceCall
+{
+    QueuedFileServiceCall()
+        : m_connection(QDBusConnection::sessionBus())
+    {
+    }
+
+    QueuedFileServiceCall(const QDBusConnection &connection, const QDBusMessage &message)
+        : m_connection(connection)
+        , m_message(message)
+    {
+    }
+
+    QDBusConnection m_connection;
+    QDBusMessage m_message;
+};
+
 
 typedef QWaylandClient WaylandClient;
 
@@ -165,6 +182,11 @@ public:
         openUrl(QUrl(url));
     }
     Q_INVOKABLE bool openUrl(const QUrl &);
+    void checkMimeSupported(const QString &mimeType, const QDBusMessage &message,
+                            const QDBusConnection &connection);
+    void checkUrlSupported(const QString &url, const QDBusMessage &message,
+                           const QDBusConnection &connection);
+    void respondSupportCheck(uint requestId, bool supported);
 
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &);
     LipstickCompositorProcWindow *mapProcWindow(const QString &title, const QString &category, const QRect &,
@@ -222,6 +244,8 @@ signals:
     void showUnlockScreen();
 
     void openUrlRequested(const QUrl &url);
+    void checkMimeSupportedRequested(uint requestId, const QString &mimeType);
+    void checkUrlSupportedRequested(uint requestId, const QUrl &url);
 
 private slots:
     void surfaceMapped();
@@ -296,6 +320,8 @@ private:
     int m_fakeRepaintTimerId;
 
     QList<QueuedSetUpdatesEnabledCall> m_queuedSetUpdatesEnabledCalls;
+    QHash<uint, QueuedFileServiceCall> m_queuedFileServiceCalls;
+    uint m_nextFileServiceCallId;
     QMceNameOwner *m_mceNameOwner;
 
     QString m_logindSession;


### PR DESCRIPTION
Sometimes apps need to check if a particular filetype or URI scheme is supported by some app in the system. This adds two methods to the fileservice next to canOpen to do that, one for MIME types and one for URIs.