### PR TITLE
Adjust window raise method naming

### DIFF
--- a/src/components/launcheritem.cpp
+++ b/src/components/launcheritem.cpp
@@ -344,18 +344,18 @@ bool LauncherItem::shouldDisplay() const
 {
     if (m_desktopEntry.isNull()) {
         return m_isTemporary;
-    } else {
-        return !m_desktopEntry->noDisplay() && !m_desktopEntry->notShowIn().contains(QStringLiteral("X-MeeGo"));
     }
+
+    return !m_desktopEntry->noDisplay() && !m_desktopEntry->notShowIn().contains(QStringLiteral("X-MeeGo"));
 }
 
 bool LauncherItem::isSandboxed() const
 {
     if (m_sandboxingInfoFetched) {
         return m_sandboxed;
-    } else {
-        return !m_desktopEntry.isNull() && m_desktopEntry->isSandboxed();
     }
+
+    return !m_desktopEntry.isNull() && m_desktopEntry->isSandboxed();
 }
 
 bool LauncherItem::isValid() const
@@ -467,6 +467,7 @@ void LauncherItem::launchWithArguments(const QStringList &arguments)
                     NULL,
                     NULL,
                     &error);
+
         if (error != NULL) {
             qCWarning(lcLipstickAppLaunchLog) << "Failed to execute" << filename() << error->message;
             g_error_free(error);

--- a/src/compositor/windowmodel.cpp
+++ b/src/compositor/windowmodel.cpp
@@ -190,8 +190,14 @@ bool WindowModel::isPrivileged() const
     return true;
 }
 
-// used by mapplauncherd to bring a binary to the front
 void WindowModel::launchProcess(const QString &binaryName)
+{
+    qWarning() << "Deprecated Lipstick WindowModel.launchProcess d-bus method called. Use raiseProcessWindow.";
+    raiseProcessWindow(binaryName);
+}
+
+// used by mapplauncherd to bring a binary to the front
+void WindowModel::raiseProcessWindow(const QString &binaryName)
 {
     LipstickCompositor *c = LipstickCompositor::instance();
     if (!m_complete || !c || !isPrivileged())

--- a/src/compositor/windowmodel.h
+++ b/src/compositor/windowmodel.h
@@ -56,6 +56,8 @@ protected:
     virtual bool approveWindow(LipstickCompositorWindow *);
 
 public slots:
+    void raiseProcessWindow(const QString &binaryName);
+    // deprecated
     void launchProcess(const QString &binaryName);
 
 private:

--- a/src/compositor/windowmodel.h
+++ b/src/compositor/windowmodel.h
@@ -50,8 +50,8 @@ signals:
     void itemAdded(int index);
 
 protected:
-    virtual void classBegin();
-    virtual void componentComplete();
+    void classBegin() override;
+    void componentComplete() override;
 
     virtual bool approveWindow(LipstickCompositorWindow *);
 

--- a/src/notifications/notificationlistmodel.cpp
+++ b/src/notifications/notificationlistmodel.cpp
@@ -33,12 +33,16 @@ NotificationListModel::NotificationListModel(QObject *parent)
     : QObjectListModel(parent)
     , m_populated(false)
 {
-    connect(NotificationManager::instance(), SIGNAL(notificationsModified(const QList<uint> &)), this, SLOT(updateNotifications(const QList<uint> &)));
-    connect(NotificationManager::instance(), SIGNAL(notificationRemoved(uint)), this, SLOT(removeNotification(uint)));
-    connect(NotificationManager::instance(), SIGNAL(notificationsRemoved(const QList<uint> &)), this, SLOT(removeNotifications(const QList<uint> &)));
-    connect(this, SIGNAL(clearRequested()), NotificationManager::instance(), SLOT(removeUserRemovableNotifications()));
+    connect(NotificationManager::instance(), &NotificationManager::notificationsModified,
+            this, &NotificationListModel::updateNotifications);
+    connect(NotificationManager::instance(), &NotificationManager::notificationRemoved,
+            this, &NotificationListModel::removeNotification);
+    connect(NotificationManager::instance(), &NotificationManager::notificationsRemoved,
+            this, &NotificationListModel::removeNotifications);
+    connect(this, &NotificationListModel::clearRequested,
+            NotificationManager::instance(), &NotificationManager::removeUserRemovableNotifications);
 
-    QTimer::singleShot(0, this, SLOT(init()));
+    QTimer::singleShot(0, this, &NotificationListModel::init);
 }
 
 NotificationListModel::~NotificationListModel()

--- a/src/utilities/qobjectlistmodel.cpp
+++ b/src/utilities/qobjectlistmodel.cpp
@@ -84,7 +84,8 @@ void QObjectListModel::insertItem(int index, QObject *item)
 {
     beginInsertRows(QModelIndex(), index, index);
     _list->insert(index, item);
-    connect(item, SIGNAL(destroyed()), this, SLOT(removeDestroyedItem()));
+    connect(item, &QObject::destroyed,
+            this, &QObjectListModel::removeDestroyedItem);
     endInsertRows();
 
     emit itemAdded(item);
@@ -103,7 +104,8 @@ void QObjectListModel::addItems(const QList<QObject *> &items)
         beginInsertRows(QModelIndex(), index, (index + items.count() - 1));
         foreach (QObject *item, items) {
             _list->append(item);
-            connect(item, SIGNAL(destroyed()), this, SLOT(removeDestroyedItem()));
+            connect(item, &QObject::destroyed,
+                    this, &QObjectListModel::removeDestroyedItem);
         }
         endInsertRows();
 
@@ -126,7 +128,8 @@ void QObjectListModel::removeItem(QObject *item)
     if (index >= 0) {
         beginRemoveRows(QModelIndex(), index, index);
         _list->removeAt(index);
-        disconnect(item, SIGNAL(destroyed()), this, SLOT(removeDestroyedItem()));
+        disconnect(item, &QObject::destroyed,
+                   this, &QObjectListModel::removeDestroyedItem);
         endRemoveRows();
         emit itemRemoved(item);
         emit itemCountChanged();
@@ -166,7 +169,8 @@ void QObjectListModel::removeItems(const QList<QObject *> &items)
                 --last;
 
                 _list->removeAt(removal.first);
-                disconnect(removal.second, SIGNAL(destroyed()), this, SLOT(removeDestroyedItem()));
+                disconnect(removal.second, &QObject::destroyed,
+                           this, &QObjectListModel::removeDestroyedItem);
             }
             endRemoveRows();
 
@@ -185,7 +189,8 @@ void QObjectListModel::removeItems(const QList<QObject *> &items)
 void QObjectListModel::removeItem(int index)
 {
     beginRemoveRows(QModelIndex(), index, index);
-    disconnect(((QObject*)_list->at(index)), SIGNAL(destroyed()), this, SLOT(removeDestroyedItem()));
+    disconnect(((QObject*)_list->at(index)), &QObject::destroyed,
+               this, &QObjectListModel::removeDestroyedItem);
     QObject *item = _list->takeAt(index);
     endRemoveRows();
     emit itemRemoved(item);


### PR DESCRIPTION
This doesn't really launch anything. Added a new name that matched the reality better. Old kept for now with some warning. I don't think it should be called from elsewhere but playing it safe.

Some connect() syntax updates while at it.