### PR TITLE
Fix unit test

### DIFF
--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -879,7 +879,7 @@ LauncherItem *LauncherModel::temporaryItemToReplace()
         // Only one item. It must be this.
         item = m_temporaryLaunchers.first();
     } else {
-        foreach(LauncherItem *tempItem, m_temporaryLaunchers) {
+        foreach (LauncherItem *tempItem, m_temporaryLaunchers) {
             if (!tempItem->isUpdating()) {
                 if (!item) {
                     // Pick the finished item.

--- a/src/notifications/batterynotifier.cpp
+++ b/src/notifications/batterynotifier.cpp
@@ -235,7 +235,7 @@ void BatteryNotifier::onEvaluateStateTimeout()
                                        m_previousState, m_currentState,
                                        toRemove, toSend);
     removeNotifications(toRemove);
-    foreach(NotificationType type, toSend)
+    foreach (NotificationType type, toSend)
         sendNotification(type);
     m_previousState = m_currentState;
     updateLowBatteryNotifier();

--- a/src/notifications/categorydefinitionstore.cpp
+++ b/src/notifications/categorydefinitionstore.cpp
@@ -58,7 +58,7 @@ void CategoryDefinitionStore::updateCategoryDefinitionFileList()
         QSet<QString> files = categoryDefinitionsDir.entryList(filter, QDir::Files).toSet();
         QSet<QString> removedFiles = m_categoryDefinitionFiles - files;
 
-        foreach(const QString &removedCategory, removedFiles) {
+        foreach (const QString &removedCategory, removedFiles) {
             QString category = QFileInfo(removedCategory).completeBaseName();
             QString categoryDefinitionPath = m_categoryDefinitionsPath + removedCategory;
             m_categoryDefinitionPathWatcher.removePath(categoryDefinitionPath);
@@ -69,7 +69,7 @@ void CategoryDefinitionStore::updateCategoryDefinitionFileList()
         m_categoryDefinitionFiles = files;
 
         // Add category definition files to watcher
-        foreach(QString file, m_categoryDefinitionFiles){
+        foreach (QString file, m_categoryDefinitionFiles){
             QString categoryDefinitionFilePath = m_categoryDefinitionsPath + file;
             if (!m_categoryDefinitionPathWatcher.files().contains(categoryDefinitionFilePath)) {
                 m_categoryDefinitionPathWatcher.addPath(categoryDefinitionFilePath);

--- a/src/notifications/notificationlistmodel.cpp
+++ b/src/notifications/notificationlistmodel.cpp
@@ -57,13 +57,13 @@ bool NotificationListModel::populated() const
 void NotificationListModel::init()
 {
     if (m_populated) {
-        foreach(uint id, NotificationManager::instance()->notificationIds()) {
+        foreach (uint id, NotificationManager::instance()->notificationIds()) {
             updateNotification(id);
         }
     } else {
         QList<QObject *> initialNotifications;
 
-        foreach(uint id, NotificationManager::instance()->notificationIds()) {
+        foreach (uint id, NotificationManager::instance()->notificationIds()) {
             LipstickNotification *notification = NotificationManager::instance()->notification(id);
             if (notificationShouldBeShown(notification)) {
                 initialNotifications.append(notification);
@@ -82,7 +82,7 @@ void NotificationListModel::updateNotification(uint id)
 {
     LipstickNotification *notification = NotificationManager::instance()->notification(id);
 
-    if (notification != 0) {
+    if (notification) {
         int currentIndex = indexOf(notification);
         if (notificationShouldBeShown(notification)) {
             // Place the notifications in the model latest first, moving existing notifications if necessary

--- a/src/notifications/notificationlistmodel.cpp
+++ b/src/notifications/notificationlistmodel.cpp
@@ -72,10 +72,10 @@ void NotificationListModel::init()
 
         sortNotifications(initialNotifications);
         addItems(initialNotifications);
-    }
 
-    m_populated = true;
-    emit populatedChanged(m_populated);
+        m_populated = true;
+        emit populatedChanged(m_populated);
+    }
 }
 
 void NotificationListModel::updateNotification(uint id)

--- a/src/notifications/notificationmanager.cpp
+++ b/src/notifications/notificationmanager.cpp
@@ -1373,7 +1373,7 @@ void NotificationManager::execSQL(const QString &command, const QVariantList &ar
     QSqlQuery query(*m_database);
     query.prepare(command);
 
-    foreach(const QVariant &arg, args) {
+    foreach (const QVariant &arg, args) {
         query.addBindValue(arg);
     }
 
@@ -1507,7 +1507,7 @@ void NotificationManager::removeUserRemovableNotifications()
     closeNotifications(closableNotifications, NotificationDismissedByUser);
 
     // Remove any remaining notifications
-    foreach(uint id, m_notifications.keys()) {
+    foreach (uint id, m_notifications.keys()) {
         removeNotificationIfUserRemovable(id);
     }
 }

--- a/tests/ut_notificationlistmodel/ut_notificationlistmodel.cpp
+++ b/tests/ut_notificationlistmodel/ut_notificationlistmodel.cpp
@@ -18,16 +18,6 @@
 #include "notificationmanager_stub.h"
 #include "lipsticknotification.h"
 
-void QTimer::singleShot(int, const QObject *receiver, const char *member)
-{
-    // The "member" string is of form "1member()", so remove the trailing 1 and the ()
-    int memberLength = strlen(member) - 3;
-    char modifiedMember[memberLength + 1];
-    strncpy(modifiedMember, member + 1, memberLength);
-    modifiedMember[memberLength] = 0;
-    QMetaObject::invokeMethod(const_cast<QObject *>(receiver), modifiedMember, Qt::DirectConnection);
-}
-
 void Ut_NotificationListModel::init()
 {
 }
@@ -40,18 +30,24 @@ void Ut_NotificationListModel::cleanup()
 void Ut_NotificationListModel::testSignalConnections()
 {
     NotificationListModel model;
-    QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationsModified(const QList<uint> &)), &model, SLOT(updateNotifications(const QList<uint> &))), true);
-    QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationRemoved(uint)), &model, SLOT(removeNotification(uint))), true);
-    QCOMPARE(disconnect(NotificationManager::instance(), SIGNAL(notificationsRemoved(const QList<uint> &)), &model, SLOT(removeNotifications(const QList<uint> &))), true);
-    QCOMPARE(disconnect(&model, SIGNAL(clearRequested()), NotificationManager::instance(), SLOT(removeUserRemovableNotifications())), true);
+    QVERIFY(disconnect(NotificationManager::instance(), &NotificationManager::notificationsModified,
+                        &model, &NotificationListModel::updateNotifications));
+    QVERIFY(disconnect(NotificationManager::instance(), &NotificationManager::notificationRemoved,
+                        &model, &NotificationListModel::removeNotification));
+    QVERIFY(disconnect(NotificationManager::instance(), &NotificationManager::notificationsRemoved,
+                        &model, &NotificationListModel::removeNotifications));
+    QVERIFY(disconnect(&model, &NotificationListModel::clearRequested,
+                        NotificationManager::instance(), &NotificationManager::removeUserRemovableNotifications));
 }
 
 void Ut_NotificationListModel::testModelPopulatesOnConstruction()
 {
-    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body", QStringList() << "action", QVariantHash(), 1);
+    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body",
+                                      QStringList() << "action", QVariantHash(), 1);
     gNotificationManagerStub->stubSetReturnValue("notificationIds", QList<uint>() << 1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification);
     NotificationListModel model;
+    QTest::qWait(1); // allow model to trigger init
     QCOMPARE(model.populated(), true);
     QCOMPARE(model.itemCount(), 1);
     QCOMPARE(model.get(0), &notification);
@@ -59,10 +55,12 @@ void Ut_NotificationListModel::testModelPopulatesOnConstruction()
 
 void Ut_NotificationListModel::testNotificationIsOnlyAddedIfNotAlreadyAdded()
 {
-    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body", QStringList() << "action", QVariantHash(), 1);
+    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body",
+                                      QStringList() << "action", QVariantHash(), 1);
     gNotificationManagerStub->stubSetReturnValue("notificationIds", QList<uint>() << 1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification);
     NotificationListModel model;
+    QTest::qWait(1);
     model.updateNotification(1);
     QCOMPARE(model.itemCount(), 1);
 }
@@ -84,27 +82,33 @@ void Ut_NotificationListModel::testNotificationIsNotAddedIfNoSummaryOrBody()
     QFETCH(QString, body);
     QFETCH(int, addItemCount);
 
-    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", summary, body, QStringList() << "action", QVariantHash(), 1);
+    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", summary, body,
+                                      QStringList() << "action", QVariantHash(), 1);
     gNotificationManagerStub->stubSetReturnValue("notificationIds", QList<uint>() << 1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification);
     NotificationListModel model;
+    QTest::qWait(1);
     QCOMPARE(model.itemCount(), addItemCount);
 }
 
 void Ut_NotificationListModel::testAlreadyAddedNotificationIsRemovedIfNoLongerAddable()
 {
-    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "", "", QStringList() << "action", QVariantHash(), 1);
+    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "", "",
+                                      QStringList() << "action", QVariantHash(), 1);
     gNotificationManagerStub->stubSetReturnValue("notificationIds", QList<uint>() << 1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification);
     NotificationListModel model;
+    QTest::qWait(1);
     QCOMPARE(model.itemCount(), 0);
 }
 
 void Ut_NotificationListModel::testNotificationRemoval()
 {
-    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body", QStringList() << "action", QVariantHash(), 1);
+    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body",
+                                      QStringList() << "action", QVariantHash(), 1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification);
     NotificationListModel model;
+    QTest::qWait(1);
     model.removeNotification(1);
     QCOMPARE(model.itemCount(), 0);
     QCOMPARE(model.populated(), true);
@@ -113,15 +117,19 @@ void Ut_NotificationListModel::testNotificationRemoval()
 void Ut_NotificationListModel::testNotificationOrdering()
 {
     NotificationListModel model;
+    QTest::qWait(1);
     QVariantHash hints1;
     QVariantHash hints2;
     QVariantHash hints3;
     hints1.insert(LipstickNotification::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 1), QTime(12, 34, 56)));
     hints2.insert(LipstickNotification::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 3), QTime(12, 34, 56)));
     hints3.insert(LipstickNotification::HINT_TIMESTAMP, QDateTime(QDate(2013, 1, 5), QTime(12, 34, 56)));
-    LipstickNotification notification1("appName1", "appName1", "appName1", 1, "appIcon1", "summary1", "body1", QStringList() << "action1", hints1, 1);
-    LipstickNotification notification2("appName2", "appName2", "appName2", 2, "appIcon2", "summary2", "body2", QStringList() << "action2", hints2, 1);
-    LipstickNotification notification3("appName3", "appName3", "appName3", 3, "appIcon3", "summary3", "body3", QStringList() << "action3", hints3, 1);
+    LipstickNotification notification1("appName1", "appName1", "appName1", 1, "appIcon1", "summary1", "body1",
+                                       QStringList() << "action1", hints1, 1);
+    LipstickNotification notification2("appName2", "appName2", "appName2", 2, "appIcon2", "summary2", "body2",
+                                       QStringList() << "action2", hints2, 1);
+    LipstickNotification notification3("appName3", "appName3", "appName3", 3, "appIcon3", "summary3", "body3",
+                                       QStringList() << "action3", hints3, 1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification1);
     model.updateNotification(1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification3);
@@ -152,11 +160,13 @@ void Ut_NotificationListModel::testNotificationOrdering()
 
 void Ut_NotificationListModel::testNotificationUpdate()
 {
-    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body", QStringList() << "action", QVariantHash(), 1);
+    LipstickNotification notification("appName", "appName", "appName", 1, "appIcon", "summary", "body",
+                                      QStringList() << "action", QVariantHash(), 1);
     gNotificationManagerStub->stubSetReturnValue("notificationIds", QList<uint>() << 1);
     gNotificationManagerStub->stubSetReturnValue("notification", &notification);
 
     NotificationListModel model;
+    QTest::qWait(1);
     QCOMPARE(model.itemCount(), 1);
     QCOMPARE(model.get(0)->property("id").value<uint>(), 1u);
 
@@ -195,6 +205,7 @@ void Ut_NotificationListModel::testRemoteActions()
     gNotificationManagerStub->stubSetReturnValue("notification", &notification);
 
     NotificationListModel model;
+    QTest::qWait(1);
     QCOMPARE(model.itemCount(), 1);
     LipstickNotification *modelNotification(qobject_cast<LipstickNotification *>(model.get(0)));
     QCOMPARE(modelNotification, &notification);

--- a/tools/notificationtool/notificationtool.cpp
+++ b/tools/notificationtool/notificationtool.cpp
@@ -199,7 +199,7 @@ int parseArguments(int argc, char *argv[])
                 action.append(actionList.takeFirst()).append(' ');
                 action.append(actionList.takeFirst());
 
-                foreach(const QString &arg, actionList) {
+                foreach (const QString &arg, actionList) {
                     // Serialize the QVariant into a QBuffer
                     QBuffer buffer;
                     buffer.open(QIODevice::ReadWrite);


### PR DESCRIPTION
Main commit:

    The new connect() syntax on commit 6f8586b58758 made this fail,
    mostly due to stubbed QTimer::singleShot() which no longer got called.
    
    Good reminder that stubbing is bad. Now instead just doing a manual
    qWait(1) and allowing the model to do its init however it likes
    within that.
