### PR TITLE
[launcher] Preserve icons across alias changes. Fixes JB#65003

### DIFF
--- a/src/components/launcherfoldermodel.cpp
+++ b/src/components/launcherfoldermodel.cpp
@@ -494,7 +494,7 @@ void LauncherFolderModel::blacklistApps(LauncherFolderItem *folder, const QStrin
         if (item && m_launcherModel->isBlacklisted(item)) {
             item->setIsBlacklisted(true);
             if (!m_loading) {
-                m_blacklistedApplications.insert(item->filePath(), buildBlacklistValue(directoryId, i));
+                m_blacklistedApplicationPositions.insert(item->filePath(), buildBlacklistValue(directoryId, i));
             }
         } else if (LauncherFolderItem *subFolder = qobject_cast<LauncherFolderItem*>(folder->get(i))) {
             blacklistApps(subFolder, subFolder->directoryFile());
@@ -504,15 +504,15 @@ void LauncherFolderModel::blacklistApps(LauncherFolderItem *folder, const QStrin
 
 void LauncherFolderModel::removeAppsFromBlacklist()
 {
-    QMap<QString, QString>::iterator i = m_blacklistedApplications.begin();
+    QMap<QString, QString>::iterator i = m_blacklistedApplicationPositions.begin();
 
     // Same index can exist in subfolders. Thus, multimap.
     QMultiMap<int, FolderItem*> unblacklistedItems;
 
-    while (i != m_blacklistedApplications.end()) {
+    while (i != m_blacklistedApplicationPositions.end()) {
         LauncherItem* item = m_launcherModel->itemInModel(i.key());
         if (!item) {
-            i = m_blacklistedApplications.erase(i);
+            i = m_blacklistedApplicationPositions.erase(i);
         } else if (!m_launcherModel->isBlacklisted(item)) {
             QString positionId = i.value();
             QString directory;
@@ -526,7 +526,7 @@ void LauncherFolderModel::removeAppsFromBlacklist()
 
             unblacklistedItems.insert(index, new FolderItem(folder, item));
             item->setIsBlacklisted(false);
-            i = m_blacklistedApplications.erase(i);
+            i = m_blacklistedApplicationPositions.erase(i);
         } else {
             ++i;
         }
@@ -552,8 +552,8 @@ void LauncherFolderModel::removeAppsFromBlacklist()
 void LauncherFolderModel::updateAppsInBlacklistedFolders()
 {
     QMap<QString, QString> tmpDesktopFiles;
-    QMap<QString, QString>::iterator i = m_blacklistedApplications.begin();
-    while (i != m_blacklistedApplications.end()) {
+    QMap<QString, QString>::iterator i = m_blacklistedApplicationPositions.begin();
+    while (i != m_blacklistedApplicationPositions.end()) {
         QString positionId = i.value();
         QString directory;
         int index = -1;
@@ -561,7 +561,7 @@ void LauncherFolderModel::updateAppsInBlacklistedFolders()
         if (!findContainerFolder(directory) && positionId.startsWith(directory)) {
             positionId.remove(directory + "-");
             tmpDesktopFiles.insert(i.key(), positionId);
-            i = m_blacklistedApplications.erase(i);
+            i = m_blacklistedApplicationPositions.erase(i);
         } else {
             ++i;
         }
@@ -569,7 +569,7 @@ void LauncherFolderModel::updateAppsInBlacklistedFolders()
 
     i = tmpDesktopFiles.begin();
     while (i != tmpDesktopFiles.end()) {
-        m_blacklistedApplications.insert(i.key(), i.value());
+        m_blacklistedApplicationPositions.insert(i.key(), i.value());
         ++i;
     }
 }
@@ -647,9 +647,9 @@ void LauncherFolderModel::appRemoved(QObject *item)
 
 void LauncherFolderModel::onAppReplaced(LauncherItem *item, const QString &oldFilePath)
 {
-    if (m_blacklistedApplications.contains(oldFilePath)) {
-        const QString position = m_blacklistedApplications.take(oldFilePath);
-        m_blacklistedApplications.insert(item->filePath(), position);
+    if (m_blacklistedApplicationPositions.contains(oldFilePath)) {
+        const QString position = m_blacklistedApplicationPositions.take(oldFilePath);
+        m_blacklistedApplicationPositions.insert(item->filePath(), position);
     }
 
     updateblacklistedApplications();
@@ -671,8 +671,8 @@ void LauncherFolderModel::updateblacklistedApplications()
     QString positionId;
     blacklistApps(this, positionId);
 
-    QMap<QString, QString>::iterator i = m_blacklistedApplications.begin();
-    while (i != m_blacklistedApplications.end()) {
+    QMap<QString, QString>::iterator i = m_blacklistedApplicationPositions.begin();
+    while (i != m_blacklistedApplicationPositions.end()) {
         LauncherItem *item = m_launcherModel->itemInModel(i.key());
         LauncherFolderItem *folder = findContainer(item);
         if (folder) {
@@ -757,12 +757,12 @@ void LauncherFolderModel::saveFolder(QXmlStreamWriter &xml, LauncherFolderItem *
         // Blacklisted apps have been removed from the LauncherFolderModel already over here.
         // Populate the menu still so that it contains also blacklisted apps.
         QStringList desktopFiles;
-        if (!m_blacklistedApplications.key(currentPosId).isEmpty()) {
-            desktopFiles = m_blacklistedApplications.keys(currentPosId);
+        if (!m_blacklistedApplicationPositions.key(currentPosId).isEmpty()) {
+            desktopFiles = m_blacklistedApplicationPositions.keys(currentPosId);
         } else if (folder && !folder->directoryFile().isEmpty()) {
             // If app is in out of bounds indexes of the current folder.
-            QMap<QString, QString>::const_iterator iter = m_blacklistedApplications.constBegin();
-            while (iter != m_blacklistedApplications.constEnd()) {
+            QMap<QString, QString>::const_iterator iter = m_blacklistedApplicationPositions.constBegin();
+            while (iter != m_blacklistedApplicationPositions.constEnd()) {
                 QString positionId = iter.value();
                 QString directory;
                 int folderIndex;
@@ -857,7 +857,7 @@ void LauncherFolderModel::load()
                                     positionId = QString("%1-%2").arg(folder->directoryFile()).arg(lastIndex);
                                 }
 
-                                m_blacklistedApplications.insert(item->filePath(), positionId);
+                                m_blacklistedApplicationPositions.insert(item->filePath(), positionId);
                             }
                         }
                     }
@@ -876,7 +876,7 @@ void LauncherFolderModel::load()
                 if (!item->isBlacklisted()) {
                     addItem(item);
                 } else {
-                    m_blacklistedApplications.insert(item->filePath(), QString::number(itemCount()));
+                    m_blacklistedApplicationPositions.insert(item->filePath(), QString::number(itemCount()));
                 }
             }
         }

--- a/src/components/launcherfoldermodel.cpp
+++ b/src/components/launcherfoldermodel.cpp
@@ -385,6 +385,8 @@ LauncherFolderModel::LauncherFolderModel(QObject *parent)
     connect(m_launcherModel, &LauncherModel::blacklistedApplicationsChanged, this, &LauncherFolderModel::updateblacklistedApplications);
     connect(m_launcherModel, &LauncherModel::iconDirectoriesChanged, this, &LauncherFolderModel::iconDirectoriesChanged);
     connect(m_launcherModel, &LauncherModel::categoriesChanged, this, &LauncherFolderModel::categoriesChanged);
+    connect(m_launcherModel, &LauncherModel::replacementIdentityKeyChanged,
+            this, &LauncherFolderModel::replacementIdentityKeyChanged);
 
     initialize();
 }
@@ -400,6 +402,8 @@ LauncherFolderModel::LauncherFolderModel(InitializationMode, QObject *parent)
     connect(m_launcherModel, &LauncherModel::blacklistedApplicationsChanged, this, &LauncherFolderModel::updateblacklistedApplications);
     connect(m_launcherModel, &LauncherModel::iconDirectoriesChanged, this, &LauncherFolderModel::iconDirectoriesChanged);
     connect(m_launcherModel, &LauncherModel::categoriesChanged, this, &LauncherFolderModel::categoriesChanged);
+    connect(m_launcherModel, &LauncherModel::replacementIdentityKeyChanged,
+            this, &LauncherFolderModel::replacementIdentityKeyChanged);
 }
 
 void LauncherFolderModel::initialize()
@@ -415,6 +419,8 @@ void LauncherFolderModel::initialize()
             this, SLOT(appRemoved(QObject*)));
     connect(m_launcherModel, SIGNAL(itemAdded(QObject*)),
             this, SLOT(appAdded(QObject*)));
+    connect(m_launcherModel, &LauncherModel::launcherReplaced,
+            this, &LauncherFolderModel::onAppReplaced);
     connect(m_launcherModel, (void (LauncherModel::*)(LauncherItem *))&LauncherModel::notifyLaunching,
             this, &LauncherFolderModel::notifyLaunching);
     connect(m_launcherModel, (void (LauncherModel::*)(LauncherItem *))&LauncherModel::canceledNotifyLaunching,
@@ -592,6 +598,16 @@ QStringList LauncherFolderModel::blacklistedApplications() const
     return m_launcherModel->blacklistedApplications();
 }
 
+QString LauncherFolderModel::replacementIdentityKey() const
+{
+    return m_launcherModel->replacementIdentityKey();
+}
+
+void LauncherFolderModel::setReplacementIdentityKey(const QString &key)
+{
+    m_launcherModel->setReplacementIdentityKey(key);
+}
+
 // Move item to folder at index. If index < 0 the item will be appended.
 bool LauncherFolderModel::moveToFolder(QObject *item, LauncherFolderItem *folder, int index)
 {
@@ -627,6 +643,17 @@ void LauncherFolderModel::appRemoved(QObject *item)
         folder->removeItem(item);
         scheduleSave();
     }
+}
+
+void LauncherFolderModel::onAppReplaced(LauncherItem *item, const QString &oldFilePath)
+{
+    if (m_blacklistedApplications.contains(oldFilePath)) {
+        const QString position = m_blacklistedApplications.take(oldFilePath);
+        m_blacklistedApplications.insert(item->filePath(), position);
+    }
+
+    updateblacklistedApplications();
+    scheduleSave();
 }
 
 // An app added to system

--- a/src/components/launcherfoldermodel.h
+++ b/src/components/launcherfoldermodel.h
@@ -97,6 +97,7 @@ class LIPSTICK_EXPORT LauncherFolderModel : public LauncherFolderItem
     Q_PROPERTY(QStringList iconDirectories READ iconDirectories WRITE setIconDirectories NOTIFY iconDirectoriesChanged)
     Q_PROPERTY(QStringList categories READ categories WRITE setCategories NOTIFY categoriesChanged)
     Q_PROPERTY(QStringList blacklistedApplications READ blacklistedApplications WRITE setBlacklistedApplications NOTIFY blacklistedApplicationsChanged)
+    Q_PROPERTY(QString replacementIdentityKey READ replacementIdentityKey WRITE setReplacementIdentityKey NOTIFY replacementIdentityKeyChanged)
     Q_PROPERTY(LauncherModel *allItems READ allItems CONSTANT)
 public:
     LauncherFolderModel(QObject *parent = 0);
@@ -118,6 +119,9 @@ public:
     QStringList blacklistedApplications() const;
     void setBlacklistedApplications(const QStringList &applications);
 
+    QString replacementIdentityKey() const;
+    void setReplacementIdentityKey(const QString &key);
+
     Q_INVOKABLE bool moveToFolder(QObject *item, LauncherFolderItem *folder, int index = -1);
 
     void import();
@@ -136,6 +140,7 @@ signals:
     void iconDirectoriesChanged();
     void categoriesChanged();
     void blacklistedApplicationsChanged();
+    void replacementIdentityKeyChanged();
     void notifyLaunching(LauncherItem *item);
     void canceledNotifyLaunching(LauncherItem *item);
     void applicationRemoved(LauncherItem *item);
@@ -153,6 +158,7 @@ private slots:
     void scheduleSave();
     void appRemoved(QObject *item);
     void appAdded(QObject *item);
+    void onAppReplaced(LauncherItem *item, const QString &oldFilePath);
 
     void updateblacklistedApplications();
 

--- a/src/components/launcherfoldermodel.h
+++ b/src/components/launcherfoldermodel.h
@@ -173,7 +173,7 @@ private:
     QTimer m_saveTimer;
     bool m_loading;
     bool m_initialized;
-    QMap<QString, QString> m_blacklistedApplications;
+    QMap<QString, QString> m_blacklistedApplicationPositions;
 
     static QString s_configDir;
 };

--- a/src/components/launcheritem.cpp
+++ b/src/components/launcheritem.cpp
@@ -581,6 +581,7 @@ bool LauncherItem::canOpenMimeType(const QString &mimeType)
 
 void LauncherItem::invalidateCaches()
 {
+    m_mimeTypes.clear();
     m_mimeTypesPopulated = false;
     m_sandboxingInfoFetched = false;
 }

--- a/src/components/launchermodel.cpp
+++ b/src/components/launchermodel.cpp
@@ -60,7 +60,8 @@ static inline QString filenameFromIconId(const QString &filename, const QString 
 
 static inline bool isVisibleDesktopFile(const QString &filename)
 {
-    LauncherItem item(filename);
+    LauncherItem item;
+    item.setFilePath(filename);
 
     return item.isValid() && item.shouldDisplay();
 }
@@ -156,10 +157,65 @@ LauncherModel::~LauncherModel()
 void LauncherModel::onFilesUpdated(const QStringList &added,
                                    const QStringList &modified, const QStringList &removed)
 {
+    QStringList addedFiles = added;
+    QStringList removedFiles = removed;
     QStringList modifiedAndNeedUpdating = modified;
 
+    // Keep the existing launcher item when a desktop file is replaced by
+    // another file with the same configured identity, so consumers do not
+    // mistake the change for an application uninstall.
+    QMap<QString, QStringList> replacementFiles;
+    if (!m_replacementIdentityKey.isEmpty()) {
+        for (const QString &filename : addedFiles) {
+            if (!isDesktopFile(m_directories, filename)) {
+                continue;
+            }
+
+            LauncherItem replacementItem;
+            replacementItem.setFilePath(filename);
+
+            if (replacementItem.isValid() && replacementItem.shouldDisplay()
+                    && displayCategory(&replacementItem)) {
+                const QString identity = replacementItem.readValue(m_replacementIdentityKey);
+                if (!identity.isEmpty()) {
+                    replacementFiles[identity].append(filename);
+                }
+            }
+        }
+
+        for (int i = removedFiles.count() - 1; i >= 0; --i) {
+            const QString oldFilePath = removedFiles.at(i);
+            LauncherItem *item = itemInModel(oldFilePath);
+            if (!item) {
+                continue;
+            }
+
+            const QString identity = item->readValue(m_replacementIdentityKey);
+            QMap<QString, QStringList>::iterator replacement = replacementFiles.find(identity);
+            if (identity.isEmpty() || replacement == replacementFiles.end()) {
+                continue;
+            }
+
+            const QString newFilePath = replacement.value().takeFirst();
+            if (replacement.value().isEmpty()) {
+                replacementFiles.erase(replacement);
+            }
+
+            LAUNCHER_DEBUG("Replacing launcher item:" << oldFilePath << "with" << newFilePath);
+            item->setIconFilename(QString());
+            item->setFilePath(newFilePath);
+            item->invalidateCaches();
+
+            addedFiles.removeOne(newFilePath);
+            removedFiles.removeAt(i);
+
+            updateItemsWithIcon(item->getOriginalIconId(), QString());
+            emit launcherReplaced(item, oldFilePath);
+        }
+    }
+
     // First, remove all removed launcher items before adding new ones
-    for (const QString &filename : removed) {
+    for (const QString &filename : removedFiles) {
         if (isDesktopFile(m_directories, filename)) {
             // Desktop file has been removed - remove launcher
             LauncherItem *item = itemInModel(filename);
@@ -174,7 +230,7 @@ void LauncherModel::onFilesUpdated(const QStringList &added,
         }
     }
 
-    for (const QString &filename : added) {
+    for (const QString &filename : addedFiles) {
         if (isDesktopFile(m_directories, filename)) {
             // New desktop file appeared - add launcher
             LauncherItem *item = itemInModel(filename);
@@ -442,6 +498,19 @@ void LauncherModel::setBlacklistedApplications(const QStringList &blacklistedApp
     if (m_blacklistedApplications != blacklistedApplications) {
         m_blacklistedApplications = blacklistedApplications;
         emit blacklistedApplicationsChanged();
+    }
+}
+
+QString LauncherModel::replacementIdentityKey() const
+{
+    return m_replacementIdentityKey;
+}
+
+void LauncherModel::setReplacementIdentityKey(const QString &key)
+{
+    if (m_replacementIdentityKey != key) {
+        m_replacementIdentityKey = key;
+        emit replacementIdentityKeyChanged();
     }
 }
 

--- a/src/components/launchermodel.h
+++ b/src/components/launchermodel.h
@@ -39,6 +39,7 @@ class LIPSTICK_EXPORT LauncherModel : public QObjectListModel
     Q_PROPERTY(QStringList iconDirectories READ iconDirectories WRITE setIconDirectories NOTIFY iconDirectoriesChanged)
     Q_PROPERTY(QStringList categories READ categories WRITE setCategories NOTIFY categoriesChanged)
     Q_PROPERTY(QStringList blacklistedApplications READ blacklistedApplications WRITE setBlacklistedApplications NOTIFY blacklistedApplicationsChanged)
+    Q_PROPERTY(QString replacementIdentityKey READ replacementIdentityKey WRITE setReplacementIdentityKey NOTIFY replacementIdentityKeyChanged)
     Q_PROPERTY(QString scope READ scope WRITE setScope NOTIFY scopeChanged)
 
     Q_ENUMS(ItemType)
@@ -64,6 +65,9 @@ public:
     QStringList blacklistedApplications() const;
     void setBlacklistedApplications(const QStringList &blacklistedApplications);
     bool isBlacklisted(LauncherItem *item) const;
+
+    QString replacementIdentityKey() const;
+    void setReplacementIdentityKey(const QString &key);
 
     QString scope() const;
     void setScope(const QString &scope);
@@ -92,7 +96,9 @@ signals:
     void iconDirectoriesChanged();
     void categoriesChanged();
     void blacklistedApplicationsChanged();
+    void replacementIdentityKeyChanged();
     void scopeChanged();
+    void launcherReplaced(LauncherItem *item, const QString &oldFilePath);
     void notifyLaunching(LauncherItem *item);
     void canceledNotifyLaunching(LauncherItem *item);
 
@@ -130,6 +136,7 @@ private:
     QStringList m_iconDirectories;
     QStringList m_categories;
     QStringList m_blacklistedApplications;
+    QString m_replacementIdentityKey;
     QFileSystemWatcher m_fileSystemWatcher;
     QSettings m_launcherSettings;
     QSettings m_globalSettings;

--- a/tests/ut_launchermodel/ut_launchermodel.cpp
+++ b/tests/ut_launchermodel/ut_launchermodel.cpp
@@ -30,6 +30,9 @@ public:
     QString m_fileName;
 };
 
+static QHash<QString, QHash<QString, QString> > desktopEntryValues;
+static QHash<QString, QStringList> desktopEntryMimeTypes;
+
 MDesktopEntry::MDesktopEntry(const QString &fileName)
     : d_ptr(new MDesktopEntryPrivate(fileName))
 {
@@ -76,6 +79,12 @@ MDesktopEntry::categories() const
     return QStringList();
 }
 
+QStringList
+MDesktopEntry::mimeType() const
+{
+    return desktopEntryMimeTypes.value(d_ptr->m_fileName);
+}
+
 QString
 MDesktopEntry::nameUnlocalized() const
 {
@@ -109,10 +118,7 @@ MDesktopEntry::hash() const
 QString
 MDesktopEntry::value(const QString &group, const QString &key) const
 {
-    Q_UNUSED(key)
-    Q_UNUSED(group)
-
-    return QString();
+    return desktopEntryValues.value(d_ptr->m_fileName).value(group + QLatin1Char('/') + key);
 }
 
 void QTimer::singleShot(int, const QObject *receiver, const char *member)
@@ -132,6 +138,8 @@ bool QFile::exists() const
 
 void Ut_LauncherModel::init()
 {
+    desktopEntryValues.clear();
+    desktopEntryMimeTypes.clear();
     launcherModel = new LauncherModel();
 }
 
@@ -143,13 +151,13 @@ void Ut_LauncherModel::cleanup()
 void Ut_LauncherModel::testUpdating()
 {
     // Test if basic updating behavior works for a random package
-    QVERIFY(launcherModel->packageInModel("somepackage") == NULL);
+    QVERIFY(launcherModel->packageInModel("somepackage") == nullptr);
 
     launcherModel->updatingStarted("somepackage", "Some Package",
                                    "/usr/share/pixmaps/example.png", "", "org.example.caller");
 
     auto item = launcherModel->packageInModel("somepackage");
-    QVERIFY(item != NULL);
+    QVERIFY(item != nullptr);
     QVERIFY(item->updatingProgress() == -1);
     QVERIFY(item->isTemporary());
     QVERIFY(launcherModel->temporaryItemToReplace() == item);
@@ -166,8 +174,8 @@ void Ut_LauncherModel::testUpdating()
 
     launcherModel->updatingFinished("somepackage", "org.example.caller");
 
-    QVERIFY(launcherModel->packageInModel("somepackage") == NULL);
-    QVERIFY(launcherModel->temporaryItemToReplace() == NULL);
+    QVERIFY(launcherModel->packageInModel("somepackage") == nullptr);
+    QVERIFY(launcherModel->temporaryItemToReplace() == nullptr);
 }
 
 void Ut_LauncherModel::testUpdatingFileAppears()
@@ -176,7 +184,7 @@ void Ut_LauncherModel::testUpdatingFileAppears()
     // launcher list, and that when the file appears during the updating phase,
     // it will properly be transformed into a non-temporary launcher item and
     // persist even after the updating phase has finished.
-    QVERIFY(launcherModel->packageInModel("somepackage") == NULL);
+    QVERIFY(launcherModel->packageInModel("somepackage") == nullptr);
 
     const QString DESKTOPFILE("/usr/share/applications/lipstick_ut_launchermodel.desktop");
 
@@ -185,7 +193,7 @@ void Ut_LauncherModel::testUpdatingFileAppears()
                                    "org.example.caller");
 
     auto item = launcherModel->packageInModel("somepackage");
-    QVERIFY(item != NULL);
+    QVERIFY(item != nullptr);
     QVERIFY(item->updatingProgress() == -1);
     QVERIFY(item->isTemporary());
     QVERIFY(launcherModel->temporaryItemToReplace() == item);
@@ -204,8 +212,73 @@ void Ut_LauncherModel::testUpdatingFileAppears()
     QVERIFY(launcherModel->itemInModel(DESKTOPFILE) == item);
     QVERIFY(!item->isUpdating());
 
-    QVERIFY(launcherModel->packageInModel("somepackage") == NULL);
-    QVERIFY(launcherModel->temporaryItemToReplace() == NULL);
+    QVERIFY(launcherModel->packageInModel("somepackage") == nullptr);
+    QVERIFY(launcherModel->temporaryItemToReplace() == nullptr);
+}
+
+void Ut_LauncherModel::testReplacingLauncherFile()
+{
+    const QString oldDesktopFile("/usr/share/applications/launcher_old.desktop");
+    const QString newDesktopFile("/usr/share/applications/launcher_new.desktop");
+    const QString replacementIdentityKey("X-Test-Replacement-Identity");
+    const QString replacementIdentity("stable-identity");
+    const QString desktopEntryKey(QStringLiteral("Desktop Entry/") + replacementIdentityKey);
+
+    desktopEntryValues[oldDesktopFile][desktopEntryKey] = replacementIdentity;
+    desktopEntryValues[newDesktopFile][desktopEntryKey] = replacementIdentity;
+    desktopEntryMimeTypes[oldDesktopFile] << QStringLiteral("application/old");
+    desktopEntryMimeTypes[newDesktopFile] << QStringLiteral("application/new");
+    launcherModel->setReplacementIdentityKey(replacementIdentityKey);
+    launcherModel->setBlacklistedApplications(QStringList() << oldDesktopFile);
+
+    launcherModel->onFilesUpdated(QStringList() << oldDesktopFile,
+                                  QStringList(), QStringList());
+    LauncherItem *item = launcherModel->itemInModel(oldDesktopFile);
+    QVERIFY(item != nullptr);
+    QVERIFY(item->canOpenMimeType(QStringLiteral("application/old")));
+    QVERIFY(!item->canOpenMimeType(QStringLiteral("application/new")));
+
+    LauncherItem *replacedItem = nullptr;
+    QString replacedFilePath;
+    connect(launcherModel, &LauncherModel::launcherReplaced,
+            [&replacedItem, &replacedFilePath](LauncherItem *item, const QString &oldFilePath) {
+        replacedItem = item;
+        replacedFilePath = oldFilePath;
+    });
+    QSignalSpy addedSpy(launcherModel, &LauncherModel::itemAdded);
+    QSignalSpy removedSpy(launcherModel, &LauncherModel::itemRemoved);
+    QSignalSpy blacklistSpy(launcherModel, &LauncherModel::blacklistedApplicationsChanged);
+
+    launcherModel->onFilesUpdated(QStringList() << newDesktopFile,
+                                  QStringList(), QStringList() << oldDesktopFile);
+
+    QCOMPARE(launcherModel->itemInModel(newDesktopFile), item);
+    QVERIFY(launcherModel->itemInModel(oldDesktopFile) == nullptr);
+    QCOMPARE(replacedItem, item);
+    QCOMPARE(replacedFilePath, oldDesktopFile);
+    QCOMPARE(addedSpy.count(), 0);
+    QCOMPARE(removedSpy.count(), 0);
+    QCOMPARE(blacklistSpy.count(), 0);
+    QCOMPARE(launcherModel->blacklistedApplications(), QStringList() << oldDesktopFile);
+    QVERIFY(!launcherModel->isBlacklisted(item));
+    QVERIFY(!item->canOpenMimeType(QStringLiteral("application/old")));
+    QVERIFY(item->canOpenMimeType(QStringLiteral("application/new")));
+}
+
+void Ut_LauncherModel::testRemovingLauncherFile()
+{
+    const QString desktopFile("/usr/share/applications/launcher_removed.desktop");
+
+    launcherModel->onFilesUpdated(QStringList() << desktopFile,
+                                  QStringList(), QStringList());
+    QVERIFY(launcherModel->itemInModel(desktopFile) != nullptr);
+
+    QSignalSpy removedSpy(launcherModel, &LauncherModel::itemRemoved);
+    launcherModel->onFilesUpdated(QStringList(),
+                                  QStringList(), QStringList() << desktopFile);
+
+    QVERIFY(launcherModel->itemInModel(desktopFile) == nullptr);
+    QCOMPARE(removedSpy.count(), 1);
 }
 
 QTEST_MAIN(Ut_LauncherModel)

--- a/tests/ut_launchermodel/ut_launchermodel.h
+++ b/tests/ut_launchermodel/ut_launchermodel.h
@@ -28,6 +28,8 @@ private slots:
     void cleanup();
     void testUpdating();
     void testUpdatingFileAppears();
+    void testReplacingLauncherFile();
+    void testRemovingLauncherFile();
 
 private:
     LauncherModel *launcherModel;


### PR DESCRIPTION
Reuse launcher items across alias desktop-file replacements, using a defined key.

Preserve folder positions and refresh filename-keyed state and caches.